### PR TITLE
feat: improve distinction between unauthorized and forbidden error.

### DIFF
--- a/api/security_test.go
+++ b/api/security_test.go
@@ -122,7 +122,7 @@ func TestBearerAuth(t *testing.T) {
 				Token: "access-token",
 			},
 
-			expectErr: models.ErrUnauthorized,
+			expectErr: api.ErrPermission,
 		},
 		{
 			name: "AuthenticateError",
@@ -148,7 +148,7 @@ func TestBearerAuth(t *testing.T) {
 				Token: "access-token",
 			},
 
-			expectErr: errFoo,
+			expectErr: api.ErrAuthentication,
 		},
 	}
 

--- a/cmd/api/integration_update_role_test.go
+++ b/cmd/api/integration_update_role_test.go
@@ -40,7 +40,7 @@ func TestUpdateRole(t *testing.T) {
 
 		require.NoError(t, err)
 
-		_, ok := rawRes.(*codegen.UnauthorizedError)
+		_, ok := rawRes.(*codegen.ForbiddenError)
 		require.True(t, ok)
 	}
 


### PR DESCRIPTION
Reserve unauthorized for invalid authentication that can be fixed automatically (seemlessly). Forbidden errors indicate a state that requires a whole new authentication flow to overcome (usually manual login).