### PR TITLE
chore(deps): bump service-json-keys to v2.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ tool github.com/vektra/mockery/v3
 require (
 	github.com/a-novel-kit/golib v0.20.29
 	github.com/a-novel-kit/jwt v1.1.55
-	github.com/a-novel/service-json-keys/v2 v2.2.6
+	github.com/a-novel/service-json-keys/v2 v2.3.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/cors v1.2.2
 	github.com/go-playground/validator/v10 v10.30.2

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/a-novel-kit/golib v0.20.29 h1:gfuqGDzNwhbhy+yfTuuiVkye4X7aXrU4738BKvK
 github.com/a-novel-kit/golib v0.20.29/go.mod h1:3r47KCHHTOYpUJRS+cymcdsF+5S+GCT80fQr7IfXOTs=
 github.com/a-novel-kit/jwt v1.1.55 h1:gAtWaAUKEWBfffQIkAm+tVLKGqIHHueaaWGExO0KcjE=
 github.com/a-novel-kit/jwt v1.1.55/go.mod h1:IegZVa2g9VUei37XMh1ltwtaNQptr+BEfpVXO4nWlJA=
-github.com/a-novel/service-json-keys/v2 v2.2.6 h1:hd1D5lIilYVI7OqQoIat+5okwggordoqJOMAd5MCFJ4=
-github.com/a-novel/service-json-keys/v2 v2.2.6/go.mod h1:isn+MbLuxP+7R8y461qIcaeIXDe61mtjqqesRjFgW7g=
+github.com/a-novel/service-json-keys/v2 v2.3.0 h1:mni8LnJttkfh1leU9ILasAS4pO6ElcS2AldrB23HqSE=
+github.com/a-novel/service-json-keys/v2 v2.3.0/go.mod h1:fVddi6Rarhq2dR/rqwmfXckScv+FgiksQcIlSjGmdVU=
 github.com/brunoga/deep v1.3.1 h1:bSrL6FhAZa6JlVv4vsi7Hg8SLwroDb1kgDERRVipBCo=
 github.com/brunoga/deep v1.3.1/go.mod h1:GDV6dnXqn80ezsLSZ5Wlv1PdKAWAO4L5PnKYtv2dgaI=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
## Summary

Pure version bump from \`service-json-keys/v2 v2.2.6\` → \`v2.3.0\`. The new release ships three breaking changes; verified that none of their surfaces are consumed here.

| Breaking change in v2.3.0 | Consumed here? |
|---|---|
| HMAC removed from \`services.JwkPrivateSources\` / \`JwkPublicSources\` | No — grep finds zero references to either type |
| \`JwkUsage\` proto enum removed | No — grep finds zero references |
| \`DependencyHealth.err\` field removed | No — only \`Status\` is read in \`http.health.go:reportJsonKeys\` |

The only \`servicejsonkeys\` surface this repo uses is \`ClaimsSign{Request,Response}\`, \`VerifyClaimsRequest\`, \`StatusRequest\`, and the \`KeyUsageAuth\` / \`KeyUsageAuthRefresh\` string constants — all stable in v2.3.0.

## Test plan

- [x] \`make lint-go\` — 0 issues
- [x] \`make test-unit\` — 243 tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)