### PR TITLE
fix(handlers): stop leaking dependency errors on /healthcheck

### DIFF
--- a/internal/handlers/http.health.go
+++ b/internal/handlers/http.health.go
@@ -21,20 +21,22 @@ const (
 	RestHealthStatusDown = "down"
 )
 
+// RestHealthStatus is the JSON representation of a single dependency's health.
+// The shape is deliberately minimal: /healthcheck is an unauthenticated public
+// endpoint, so it must not expose raw error messages — those routinely include
+// internal hostnames, ports, or schema names that leak infrastructure topology.
+// The underlying error is recorded on the trace span for operators instead.
 type RestHealthStatus struct {
+	// Status is either RestHealthStatusUp or RestHealthStatusDown.
 	Status string `json:"status"`
-	Err    string `json:"err,omitempty"`
 }
 
+// NewRestHealthStatus converts an error into a RestHealthStatus, mapping nil to
+// RestHealthStatusUp and any non-nil error to RestHealthStatusDown. The error
+// itself is intentionally discarded from the public response; see RestHealthStatus.
 func NewRestHealthStatus(err error) *RestHealthStatus {
-	errMsg := ""
-	if err != nil {
-		errMsg = err.Error()
-	}
-
 	return &RestHealthStatus{
 		Status: lo.Ternary(err == nil, RestHealthStatusUp, RestHealthStatusDown),
-		Err:    errMsg,
 	}
 }
 

--- a/internal/handlers/http.health_test.go
+++ b/internal/handlers/http.health_test.go
@@ -67,6 +67,11 @@ func TestHealth(t *testing.T) {
 			expectStatus: http.StatusOK,
 		},
 		{
+			// Each dependency mock returns an error; the response must report status=down
+			// for those dependencies WITHOUT echoing the underlying error string. The
+			// exact-match assertion on expectResponse below is the regression guard:
+			// it fails if any extra field (notably a re-introduced "err") leaks into
+			// the public response shape.
 			name: "Error",
 
 			request: httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", nil),
@@ -84,11 +89,9 @@ func TestHealth(t *testing.T) {
 				},
 				"client:smtp": map[string]any{
 					"status": handlers.RestHealthStatusDown,
-					"err":    "error smtp",
 				},
 				"api:jsonKeys": map[string]any{
 					"status": handlers.RestHealthStatusDown,
-					"err":    "error json keys",
 				},
 			},
 			expectStatus: http.StatusOK,

--- a/internal/handlers/http.health_test.go
+++ b/internal/handlers/http.health_test.go
@@ -67,11 +67,11 @@ func TestHealth(t *testing.T) {
 			expectStatus: http.StatusOK,
 		},
 		{
-			// Each dependency mock returns an error; the response must report status=down
-			// for those dependencies WITHOUT echoing the underlying error string. The
-			// exact-match assertion on expectResponse below is the regression guard:
-			// it fails if any extra field (notably a re-introduced "err") leaks into
-			// the public response shape.
+			// The SMTP and json-keys dependency mocks return errors; the response must
+			// report status=down for those dependencies WITHOUT echoing the underlying
+			// error string. The exact-match assertion on expectResponse below is the
+			// regression guard: it fails if any extra field (notably a re-introduced
+			// "err") leaks into the public response shape.
 			name: "Error",
 
 			request: httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", nil),


### PR DESCRIPTION
Mirrors service-json-keys#532. The \`RestHealthStatus\` type carried an \`Err\` field (\`json:\"err,omitempty\"\`) populated with the raw error string from each dependency probe — Postgres, SMTP, json-keys gRPC. The \`/healthcheck\` endpoint is unauthenticated and public, and dependency errors routinely embed internal hostnames, ports, schema names, or gRPC dial targets. Anyone who can hit the endpoint and trigger a dependency failure could read those.

Drops the \`Err\` field and the \`errMsg\` construction in \`NewRestHealthStatus\`. The shape now carries only \`status: up|down\`. Operators still get the underlying error from the trace span each \`report*()\` helper records on its way out.

The \`Error\` test case is updated so \`expectResponse\` no longer carries \`err:\` fields, and a comment marks the exact-match assertion as the regression guard against any future field re-introduction.

## Test plan

- [x] \`make format-go\`, \`make lint-go\` clean
- [x] \`make test-unit\` — 243 tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)