### PR TITLE
fix(middlewares): repair unreachable wrong-type branch in GetClaimsContext

### DIFF
--- a/internal/handlers/middlewares/http.auth.go
+++ b/internal/handlers/middlewares/http.auth.go
@@ -169,14 +169,19 @@ func SetClaimsContext(ctx context.Context, claims *services.AccessTokenClaims) c
 
 // GetClaimsContext retrieves the authenticated user's claims from the context.
 // Returns nil claims with no error if no authentication was provided (for optional auth endpoints).
-// Returns an error if the claims have an unexpected type.
+// Returns an error if the value stored under [ClaimsContextKey] has an unexpected type.
 func GetClaimsContext(ctx context.Context) (*services.AccessTokenClaims, error) {
-	claims, ok := ctx.Value(ClaimsContextKey{}).(*services.AccessTokenClaims)
-	if !ok && claims != nil {
+	raw := ctx.Value(ClaimsContextKey{})
+	if raw == nil {
+		return nil, nil
+	}
+
+	claims, ok := raw.(*services.AccessTokenClaims)
+	if !ok {
 		return nil, fmt.Errorf(
 			"%w: got type %T, expected %T",
 			ErrUnexpectedClaims,
-			ctx.Value(ClaimsContextKey{}),
+			raw,
 			&services.AccessTokenClaims{},
 		)
 	}

--- a/internal/handlers/middlewares/http.auth_test.go
+++ b/internal/handlers/middlewares/http.auth_test.go
@@ -1,6 +1,7 @@
 package middlewares_test
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -281,4 +282,45 @@ func TestAuth(t *testing.T) {
 			require.Equal(t, testCase.expectClaims, *ctxClaims)
 		})
 	}
+}
+
+func TestGetClaimsContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success/NoClaimsSet", func(t *testing.T) {
+		t.Parallel()
+
+		// No value stored under ClaimsContextKey — optional-auth path: returns
+		// (nil, nil) so endpoints that allow unauthenticated access can keep working.
+		claims, err := middlewares.GetClaimsContext(t.Context())
+		require.NoError(t, err)
+		require.Nil(t, claims)
+	})
+
+	t.Run("Success/ValidClaims", func(t *testing.T) {
+		t.Parallel()
+
+		want := &services.AccessTokenClaims{
+			UserID: lo.ToPtr(uuid.MustParse("00000000-0000-0000-0000-000000000001")),
+			Roles:  []string{"user"},
+		}
+		ctx := middlewares.SetClaimsContext(t.Context(), want)
+
+		got, err := middlewares.GetClaimsContext(ctx)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	})
+
+	t.Run("Error/UnexpectedClaims", func(t *testing.T) {
+		t.Parallel()
+
+		// A wrong type stored under ClaimsContextKey must surface as
+		// ErrUnexpectedClaims rather than silently returning nil claims (which
+		// would let an endpoint that only checks `claims == nil` fail open).
+		ctx := context.WithValue(t.Context(), middlewares.ClaimsContextKey{}, "not-claims")
+
+		claims, err := middlewares.GetClaimsContext(ctx)
+		require.ErrorIs(t, err, middlewares.ErrUnexpectedClaims)
+		require.Nil(t, claims)
+	})
 }


### PR DESCRIPTION
## Summary

The previous implementation of \`GetClaimsContext\` had an unreachable error branch:

\`\`\`go
claims, ok := ctx.Value(ClaimsContextKey{}).(*services.AccessTokenClaims)
if !ok && claims != nil {
    return nil, fmt.Errorf(...)
}
\`\`\`

When the type assertion fails (\`!ok\`), \`claims\` is the zero value of the asserted type — \`nil\` for a pointer. So \`!ok && claims != nil\` is impossible, and the wrong-type error path is unreachable. A wrong-type value silently returned \`(nil, nil)\`, behaviorally identical to \"no auth provided\". An endpoint that only checks \`claims == nil\` would fail open if anything ever stored a different type under \`ClaimsContextKey{}\`.

This commit restructures the function: read the raw context value once, treat \`nil\` (no value set) as the optional-auth case, and only attempt the type assertion when something is set. The wrong-type branch is now actually reachable and returns \`ErrUnexpectedClaims\`.

## Risk

The codebase has only one writer for this key (\`SetClaimsContext\` in the same file), so today nothing reaches the wrong-type path. The fix is defense-in-depth: a future writer that puts the wrong type in the context surfaces the bug at the call site instead of silently proceeding with \`nil\` claims.

\`GetClaimsContext\` and \`MustGetClaimsContext\` preserve their public contract for the cases that *can* happen today.

## Test plan

- [x] \`make format-go\`, \`make lint-go\` clean
- [x] \`make test-unit\` — 243 tests pass (the existing test exercises the optional-auth-no-token path; the wrong-type path is structurally unreachable from current writers)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)