### PR TITLE
chore: stop reporting sentinel errors as span failures

### DIFF
--- a/internal/dao/pg.shortCodeInsert.go
+++ b/internal/dao/pg.shortCodeInsert.go
@@ -153,7 +153,7 @@ func (repository *ShortCodeInsert) checkConflicts(
 	}
 
 	if n == 1 {
-		return otel.ReportError(span, ErrShortCodeInsertAlreadyExists)
+		return ErrShortCodeInsertAlreadyExists
 	}
 
 	otel.ReportSuccessNoContent(span)

--- a/internal/services/credentialsCreate.go
+++ b/internal/services/credentialsCreate.go
@@ -94,7 +94,7 @@ func (service *CredentialsCreate) Exec(ctx context.Context, request *Credentials
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
+		return nil, errors.Join(err, ErrInvalidRequest)
 	}
 
 	// Encrypt the password.

--- a/internal/services/credentialsCreateSuperAdmin.go
+++ b/internal/services/credentialsCreateSuperAdmin.go
@@ -64,7 +64,7 @@ func (service *CredentialsCreateSuperAdmin) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
+		return nil, errors.Join(err, ErrInvalidRequest)
 	}
 
 	encryptedPassword, err := lib.GenerateArgon2(request.Password, lib.Argon2ParamsDefault)

--- a/internal/services/credentialsList.go
+++ b/internal/services/credentialsList.go
@@ -41,7 +41,7 @@ func (service *CredentialsList) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
+		return nil, errors.Join(err, ErrInvalidRequest)
 	}
 
 	entities, err := service.repository.Exec(ctx, &dao.CredentialsListRequest{

--- a/internal/services/credentialsUpdateEmail.go
+++ b/internal/services/credentialsUpdateEmail.go
@@ -54,7 +54,7 @@ func (service *CredentialsUpdateEmail) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
+		return nil, errors.Join(err, ErrInvalidRequest)
 	}
 
 	var credentials *dao.Credentials

--- a/internal/services/credentialsUpdatePassword.go
+++ b/internal/services/credentialsUpdatePassword.go
@@ -66,7 +66,7 @@ func (service *CredentialsUpdatePassword) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
+		return nil, errors.Join(err, ErrInvalidRequest)
 	}
 
 	// Encrypt the new password.

--- a/internal/services/credentialsUpdateRole.go
+++ b/internal/services/credentialsUpdateRole.go
@@ -66,12 +66,12 @@ func (service *CredentialsUpdateRole) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
+		return nil, errors.Join(err, ErrInvalidRequest)
 	}
 
 	// No self-update allowed.
 	if request.CurrentUserID == request.TargetUserID {
-		return nil, otel.ReportError(span, ErrCredentialsUpdateRoleSelfUpdate)
+		return nil, ErrCredentialsUpdateRoleSelfUpdate
 	}
 
 	newTargetRoleImportance := config.PermissionsConfigDefault.Roles[request.Role].Priority

--- a/internal/services/shortCodeConsume.go
+++ b/internal/services/shortCodeConsume.go
@@ -55,7 +55,7 @@ func (service *ShortCodeConsume) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
+		return nil, errors.Join(err, ErrInvalidRequest)
 	}
 
 	entity, err := service.repositorySelect.Exec(ctx, &dao.ShortCodeSelectRequest{
@@ -70,16 +70,16 @@ func (service *ShortCodeConsume) Exec(
 
 	// Explicit expiration check as defense-in-depth (SQL already filters expired codes).
 	if entity.ExpiresAt.Before(time.Now()) {
-		return nil, otel.ReportError(span, ErrShortCodeConsumeExpired)
+		return nil, ErrShortCodeConsumeExpired
 	}
 
 	// Compare the encrypted code with the plain code of the request.
 	err = lib.CompareArgon2(request.Code, entity.Code)
 	if err != nil {
-		return nil, otel.ReportError(span, errors.Join(
+		return nil, errors.Join(
 			fmt.Errorf("compare short code: %w", err),
 			ErrShortCodeConsumeInvalid,
-		))
+		)
 	}
 
 	// Delete the short code from the database. It has been consumed.

--- a/internal/services/shortCodeConsume.go
+++ b/internal/services/shortCodeConsume.go
@@ -76,10 +76,17 @@ func (service *ShortCodeConsume) Exec(
 	// Compare the encrypted code with the plain code of the request.
 	err = lib.CompareArgon2(request.Code, entity.Code)
 	if err != nil {
-		return nil, errors.Join(
+		joined := errors.Join(
 			fmt.Errorf("compare short code: %w", err),
 			ErrShortCodeConsumeInvalid,
 		)
+		if errors.Is(err, lib.ErrInvalidPassword) {
+			// Wrong code is the expected user-facing outcome (mistyped code, stale request).
+			return nil, joined
+		}
+		// Other CompareArgon2 errors (lib.ErrInvalidHash, lib.ErrIncompatibleVersion) mean
+		// the stored short-code hash itself is malformed — operational failure worth reporting.
+		return nil, otel.ReportError(span, joined)
 	}
 
 	// Delete the short code from the database. It has been consumed.

--- a/internal/services/shortCodeCreate.go
+++ b/internal/services/shortCodeCreate.go
@@ -55,7 +55,7 @@ func (service *ShortCodeCreate) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
+		return nil, errors.Join(err, ErrInvalidRequest)
 	}
 
 	// Generate a new random code.

--- a/internal/services/shortCodeCreateEmailUpdate.go
+++ b/internal/services/shortCodeCreateEmailUpdate.go
@@ -79,14 +79,14 @@ func (service *ShortCodeCreateEmailUpdate) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
+		return nil, errors.Join(err, ErrInvalidRequest)
 	}
 
 	_, err = service.selectRepository.Exec(ctx, &dao.CredentialsSelectByEmailRequest{
 		Email: request.Email,
 	})
 	if err == nil {
-		return nil, otel.ReportError(span, dao.ErrCredentialsUpdateEmailAlreadyExists)
+		return nil, dao.ErrCredentialsUpdateEmailAlreadyExists
 	}
 
 	if !errors.Is(err, dao.ErrCredentialsSelectByEmailNotFound) {

--- a/internal/services/shortCodeCreatePasswordReset.go
+++ b/internal/services/shortCodeCreatePasswordReset.go
@@ -74,7 +74,7 @@ func (service *ShortCodeCreatePasswordReset) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
+		return nil, errors.Join(err, ErrInvalidRequest)
 	}
 
 	credentials, err := service.selectRepository.Exec(ctx, &dao.CredentialsSelectByEmailRequest{

--- a/internal/services/shortCodeCreateRegister.go
+++ b/internal/services/shortCodeCreateRegister.go
@@ -76,14 +76,14 @@ func (service *ShortCodeCreateRegister) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
+		return nil, errors.Join(err, ErrInvalidRequest)
 	}
 
 	_, err = service.selectRepository.Exec(ctx, &dao.CredentialsSelectByEmailRequest{
 		Email: request.Email,
 	})
 	if err == nil {
-		return nil, otel.ReportError(span, dao.ErrCredentialsInsertAlreadyExists)
+		return nil, dao.ErrCredentialsInsertAlreadyExists
 	}
 
 	if !errors.Is(err, dao.ErrCredentialsSelectByEmailNotFound) {

--- a/internal/services/tokenCreate.go
+++ b/internal/services/tokenCreate.go
@@ -77,7 +77,7 @@ func (service *TokenCreate) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
+		return nil, errors.Join(err, ErrInvalidRequest)
 	}
 
 	// Retrieve credentials.
@@ -96,7 +96,7 @@ func (service *TokenCreate) Exec(
 	// Validate password.
 	err = lib.CompareArgon2(request.Password, credentials.Password)
 	if err != nil {
-		return nil, otel.ReportError(span, fmt.Errorf("compare password: %w", err))
+		return nil, fmt.Errorf("compare password: %w", err)
 	}
 
 	refreshTokenPayload, err := grpcf.InterfaceToProtoAny(RefreshTokenClaimsForm{

--- a/internal/services/tokenCreate.go
+++ b/internal/services/tokenCreate.go
@@ -96,7 +96,14 @@ func (service *TokenCreate) Exec(
 	// Validate password.
 	err = lib.CompareArgon2(request.Password, credentials.Password)
 	if err != nil {
-		return nil, fmt.Errorf("compare password: %w", err)
+		if errors.Is(err, lib.ErrInvalidPassword) {
+			// Wrong password is the expected user-facing outcome — don't mark the span as
+			// failed. The handler maps lib.ErrInvalidPassword to 401 downstream.
+			return nil, fmt.Errorf("compare password: %w", err)
+		}
+		// Other CompareArgon2 errors (lib.ErrInvalidHash, lib.ErrIncompatibleVersion) mean
+		// the stored hash itself is malformed — operational failure worth reporting.
+		return nil, otel.ReportError(span, fmt.Errorf("compare password: %w", err))
 	}
 
 	refreshTokenPayload, err := grpcf.InterfaceToProtoAny(RefreshTokenClaimsForm{

--- a/internal/services/tokenRefresh.go
+++ b/internal/services/tokenRefresh.go
@@ -73,7 +73,7 @@ func (service *TokenRefresh) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
+		return nil, errors.Join(err, ErrInvalidRequest)
 	}
 
 	// Step 1: Verify the access token signature.
@@ -89,7 +89,7 @@ func (service *TokenRefresh) Exec(
 	)
 	if err != nil {
 		if errors.Is(err, jws.ErrInvalidSignature) {
-			return nil, otel.ReportError(span, errors.Join(err, ErrTokenRefreshInvalidAccessToken))
+			return nil, errors.Join(err, ErrTokenRefreshInvalidAccessToken)
 		}
 
 		return nil, otel.ReportError(span, err)
@@ -106,7 +106,7 @@ func (service *TokenRefresh) Exec(
 	)
 	if err != nil {
 		if errors.Is(err, jws.ErrInvalidSignature) {
-			return nil, otel.ReportError(span, errors.Join(err, ErrTokenRefreshInvalidRefreshToken))
+			return nil, errors.Join(err, ErrTokenRefreshInvalidRefreshToken)
 		}
 
 		return nil, otel.ReportError(span, err)
@@ -120,7 +120,7 @@ func (service *TokenRefresh) Exec(
 	// Step 3: Verify that both tokens belong to the same user.
 	// This prevents an attacker from using a stolen refresh token with a different user's access token.
 	if lo.FromPtr(accessTokenClaims.UserID) != refreshTokenClaims.UserID {
-		return nil, otel.ReportError(span, ErrTokenRefreshMismatchClaims)
+		return nil, ErrTokenRefreshMismatchClaims
 	}
 
 	span.SetAttributes(
@@ -134,7 +134,7 @@ func (service *TokenRefresh) Exec(
 	//   - An access token can only be refreshed using its original refresh token
 	//   - Revoking a refresh token effectively revokes all access tokens derived from it
 	if accessTokenClaims.RefreshTokenID != refreshTokenClaims.Jti {
-		return nil, otel.ReportError(span, ErrTokenRefreshMismatchSource)
+		return nil, ErrTokenRefreshMismatchSource
 	}
 
 	// Retrieve updated credentials.


### PR DESCRIPTION
Per the policy locked in [a-novel-kit/stack#8](https://github.com/a-novel-kit/stack/pull/8): sentinel errors — validation, not-found, expired, wrong password, signature mismatch, claim mismatch, replay, role-mismatch — are expected outcomes of expected input shapes. The protective clause caught the bad input; the application held; that is not a service failure.

Sweeps every `otel.ReportError(span, ...)` call across `services/` and `dao/` where the wrapped error is sentinel-bearing.

## Sentinels affected

- 14 `ErrInvalidRequest` paths (validation from `validate.Struct`)
- `ErrShortCodeConsumeInvalid` / `Expired`
- `ErrShortCodeInsertAlreadyExists` (dao)
- `ErrCredentialsInsertAlreadyExists`, `ErrCredentialsUpdateEmailAlreadyExists`
- `ErrCredentialsUpdateRoleSelfUpdate`
- `ErrTokenRefreshInvalidAccessToken` / `InvalidRefreshToken` / `MismatchClaims` / `MismatchSource`
- `lib.ErrInvalidPassword` propagation in tokenCreate (CompareArgon2 only ever returns lib sentinels)

Genuine infrastructure paths — db connection failure, transaction errors, token-signing RPC failure — keep `otel.ReportError`.

## No behavior change for callers

Sentinels still flow through `errors.Is` checks at the handler layer (`httpf.ErrMap` routing) and the same HTTP/gRPC status codes are returned. Only span attribution changes.

## Test plan

- [x] `make format-go`, `make lint-go` clean
- [x] `make test-unit` — 247 tests pass
- [ ] CI