### PR TITLE
fix(services): drop password/shortCode length leak from CredentialsCreate span

### DIFF
--- a/internal/services/credentialsCreate.go
+++ b/internal/services/credentialsCreate.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -89,8 +88,9 @@ func (service *CredentialsCreate) Exec(ctx context.Context, request *Credentials
 	defer span.End()
 
 	span.SetAttributes(attribute.String("email", request.Email))
-	span.SetAttributes(attribute.String("password", strings.Repeat("*", len(request.Password))))
-	span.SetAttributes(attribute.String("shortCode", strings.Repeat("*", len(request.ShortCode))))
+	// Do not record the password or short code on the span, even redacted: a "*****"
+	// of the same length still leaks the input length over every trace, which is
+	// partial credential information an attacker reading traces could correlate.
 
 	err := validate.Struct(request)
 	if err != nil {


### PR DESCRIPTION
## Summary

The `CredentialsCreate.Exec` span recorded redacted versions of the password and short code as attributes:

```go
span.SetAttributes(attribute.String("password", strings.Repeat("*", len(request.Password))))
span.SetAttributes(attribute.String("shortCode", strings.Repeat("*", len(request.ShortCode))))
```

The values are masked but the **length** is preserved on every trace. Password length is partial credential information — an attacker reading traces (or a tracing dashboard with broad read access) could correlate password length with user identity over time, narrowing brute-force attack space.

The skill is explicit: never include credentials, secret material, or full payloads in span attributes. The redaction here gave a false sense of safety; the right fix is to not record the field at all.

Drops both attributes and the now-unused `"strings"` import. Inline comment captures the rationale so future-me does not re-introduce a "redacted" version of the same leak.

Operator-side debugging context is preserved through:
- the `email` span attribute (PII, but not secret)
- the `credentials.id` span attribute that gets set after insertion

## Test plan

- [x] `make format-go`, `make lint-go` clean
- [x] `make test-unit` — 247 tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)