### PR TITLE
chore(services): rename request.* span attributes to semantic names

### DIFF
--- a/internal/services/credentialsGet.go
+++ b/internal/services/credentialsGet.go
@@ -36,7 +36,7 @@ func (service *CredentialsGet) Exec(
 	ctx, span := otel.Tracer().Start(ctx, "service.CredentialsGet")
 	defer span.End()
 
-	span.SetAttributes(attribute.String("request.userID", request.ID.String()))
+	span.SetAttributes(attribute.String("user.id", request.ID.String()))
 
 	entity, err := service.repository.Exec(ctx, &dao.CredentialsSelectRequest{ID: request.ID})
 	if err != nil {

--- a/internal/services/credentialsUpdateEmail.go
+++ b/internal/services/credentialsUpdateEmail.go
@@ -50,7 +50,7 @@ func (service *CredentialsUpdateEmail) Exec(
 	ctx, span := otel.Tracer().Start(ctx, "service.CredentialsUpdateEmail")
 	defer span.End()
 
-	span.SetAttributes(attribute.String("request.userID", request.UserID.String()))
+	span.SetAttributes(attribute.String("user.id", request.UserID.String()))
 
 	err := validate.Struct(request)
 	if err != nil {

--- a/internal/services/credentialsUpdatePassword.go
+++ b/internal/services/credentialsUpdatePassword.go
@@ -62,7 +62,7 @@ func (service *CredentialsUpdatePassword) Exec(
 	ctx, span := otel.Tracer().Start(ctx, "service.CredentialsUpdatePassword")
 	defer span.End()
 
-	span.SetAttributes(attribute.String("request.userID", request.UserID.String()))
+	span.SetAttributes(attribute.String("user.id", request.UserID.String()))
 
 	err := validate.Struct(request)
 	if err != nil {

--- a/internal/services/credentialsUpdateRole.go
+++ b/internal/services/credentialsUpdateRole.go
@@ -59,9 +59,9 @@ func (service *CredentialsUpdateRole) Exec(
 	defer span.End()
 
 	span.SetAttributes(
-		attribute.String("request.targetUserID", request.TargetUserID.String()),
-		attribute.String("request.currentUserID", request.CurrentUserID.String()),
-		attribute.String("request.role", request.Role),
+		attribute.String("target.id", request.TargetUserID.String()),
+		attribute.String("actor.id", request.CurrentUserID.String()),
+		attribute.String("target.role", request.Role),
 	)
 
 	err := validate.Struct(request)

--- a/internal/services/shortCodeCreateEmailUpdate.go
+++ b/internal/services/shortCodeCreateEmailUpdate.go
@@ -72,9 +72,9 @@ func (service *ShortCodeCreateEmailUpdate) Exec(
 	defer span.End()
 
 	span.SetAttributes(
-		attribute.String("request.id", request.ID.String()),
-		attribute.String("request.email", request.Email),
-		attribute.String("request.lang", request.Lang),
+		attribute.String("user.id", request.ID.String()),
+		attribute.String("user.email", request.Email),
+		attribute.String("email.lang", request.Lang),
 	)
 
 	err := validate.Struct(request)
@@ -122,8 +122,8 @@ func (service *ShortCodeCreateEmailUpdate) sendMail(
 	defer span.End()
 
 	span.SetAttributes(
-		attribute.String("request.email", request.Email),
-		attribute.String("request.lang", request.Lang),
+		attribute.String("user.email", request.Email),
+		attribute.String("email.lang", request.Lang),
 		attribute.String("short_code.target", shortCode.Target),
 	)
 

--- a/internal/services/shortCodeCreatePasswordReset.go
+++ b/internal/services/shortCodeCreatePasswordReset.go
@@ -68,8 +68,8 @@ func (service *ShortCodeCreatePasswordReset) Exec(
 	defer span.End()
 
 	span.SetAttributes(
-		attribute.String("request.email", request.Email),
-		attribute.String("request.lang", request.Lang),
+		attribute.String("user.email", request.Email),
+		attribute.String("email.lang", request.Lang),
 	)
 
 	err := validate.Struct(request)
@@ -112,8 +112,8 @@ func (service *ShortCodeCreatePasswordReset) sendMail(
 	defer span.End()
 
 	span.SetAttributes(
-		attribute.String("request.email", request.Email),
-		attribute.String("request.lang", request.Lang),
+		attribute.String("user.email", request.Email),
+		attribute.String("email.lang", request.Lang),
 		attribute.String("short_code.target", shortCode.Target),
 	)
 

--- a/internal/services/shortCodeCreateRegister.go
+++ b/internal/services/shortCodeCreateRegister.go
@@ -70,8 +70,8 @@ func (service *ShortCodeCreateRegister) Exec(
 	defer span.End()
 
 	span.SetAttributes(
-		attribute.String("request.email", request.Email),
-		attribute.String("request.lang", request.Lang),
+		attribute.String("user.email", request.Email),
+		attribute.String("email.lang", request.Lang),
 	)
 
 	err := validate.Struct(request)
@@ -118,8 +118,8 @@ func (service *ShortCodeCreateRegister) sendMail(
 	defer span.End()
 
 	span.SetAttributes(
-		attribute.String("request.email", request.Email),
-		attribute.String("request.lang", request.Lang),
+		attribute.String("user.email", request.Email),
+		attribute.String("email.lang", request.Lang),
 		attribute.String("short_code.target", shortCode.Target),
 	)
 


### PR DESCRIPTION
Per the `write-go-code` skill: span attribute names describe **the data**, not the Go variable holding it. The skill explicitly calls out `request.*` as an anti-pattern.

Sweeps 19 sites across 7 service files. Mapping:

| Old (implementation-named) | New (semantic) | Notes |
|---|---|---|
| `request.email` | `user.email` | every site (5 files) |
| `request.lang` | `email.lang` | every site (5 files) |
| `request.userID` | `user.id` | credentialsGet, credentialsUpdateEmail, credentialsUpdatePassword |
| `request.id` | `user.id` | shortCodeCreateEmailUpdate (the ID *is* the user being updated) |
| `request.targetUserID` | `target.id` | credentialsUpdateRole |
| `request.currentUserID` | `actor.id` | credentialsUpdateRole — the authenticated caller, distinct from the target being modified |
| `request.role` | `target.role` | credentialsUpdateRole — the new role being assigned to the target |

Same data, different identifiers — no behavior change.

> **Heads-up for tracing dashboards**: any query / filter / alert that used the old `request.*` names needs to be updated. The new names are stable, semantic, and aligned with the sentinel-cleanup PR shipped alongside.

## Test plan

- [x] `make format-go`, `make lint-go` clean
- [x] `make test-unit` — 247 tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)