### PR TITLE
fix(services): wire TokenCreateAnon to its own signer interface

### DIFF
--- a/internal/services/tokenCreateAnon.go
+++ b/internal/services/tokenCreateAnon.go
@@ -29,10 +29,10 @@ type TokenCreateAnonSignClaimsService interface {
 }
 
 type TokenCreateAnon struct {
-	signClaimsService TokenCreateServiceSignClaims
+	signClaimsService TokenCreateAnonSignClaimsService
 }
 
-func NewTokenCreateAnon(signClaimsService TokenCreateServiceSignClaims) *TokenCreateAnon {
+func NewTokenCreateAnon(signClaimsService TokenCreateAnonSignClaimsService) *TokenCreateAnon {
 	return &TokenCreateAnon{
 		signClaimsService: signClaimsService,
 	}


### PR DESCRIPTION
## Summary

`TokenCreateAnon`'s struct field and constructor were typed against `TokenCreateServiceSignClaims` (the sibling `TokenCreate` service's interface), leaving the dedicated `TokenCreateAnonSignClaimsService` declared but unused in production. The unit test already mocked the correct interface; production wiring only worked because both interfaces have an identical method shape and Go is structurally typed.

Repoint the field and constructor at `TokenCreateAnonSignClaimsService` so the test contract and the production contract refer to the same interface, and so future evolution of either signer interface can't silently leak across services.

## Why it matters

- If anyone adds a method to `TokenCreateServiceSignClaims`, `TokenCreateAnon` would silently gain a dependency on functionality it doesn't need.
- Conversely, edits to `TokenCreateAnonSignClaimsService` (which mockery happily generates) had zero effect on production today — drift the compiler can't catch in a structurally-typed language.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/services/...` clean
- [x] `TestTokenCreateAnon` passes against the existing `MockTokenCreateAnonSignClaimsService`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)