### PR TITLE
fix(dao): drop password length leak from credentials span attributes

### DIFF
--- a/internal/dao/pg.credentialsInsert.go
+++ b/internal/dao/pg.credentialsInsert.go
@@ -5,7 +5,6 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -55,7 +54,9 @@ func (repository *CredentialsInsert) Exec(
 	span.SetAttributes(
 		attribute.String("credentials.id", request.ID.String()),
 		attribute.String("credentials.email", request.Email),
-		attribute.String("credentials.password", strings.Repeat("*", len(request.Password))),
+		// Do not record the password on the span, even redacted: a "*****" of the
+		// same length leaks the input length over every trace, which is partial
+		// credential information an attacker reading traces could correlate.
 		attribute.String("credentials.role", request.Role),
 		attribute.Int64("credentials.now", request.Now.Unix()),
 	)

--- a/internal/dao/pg.credentialsUpdatePassword.go
+++ b/internal/dao/pg.credentialsUpdatePassword.go
@@ -6,7 +6,6 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -48,7 +47,9 @@ func (repository *CredentialsUpdatePassword) Exec(
 
 	span.SetAttributes(
 		attribute.String("credentials.id", request.ID.String()),
-		attribute.String("credentials.password", strings.Repeat("*", len(request.Password))),
+		// Do not record the password on the span, even redacted: a "*****" of the
+		// same length leaks the input length over every trace, which is partial
+		// credential information an attacker reading traces could correlate.
 		attribute.Int64("credentials.now", request.Now.Unix()),
 	)
 


### PR DESCRIPTION
## Summary

Two dao repositories — `CredentialsInsert` and `CredentialsUpdatePassword` — recorded `strings.Repeat("*", len(request.Password))` on the OTEL span. The placeholder is the same length as the input, which leaks the password length over every trace.

This is the **same anti-pattern fixed at the service layer in #813** (which targeted `CredentialsCreate`); the two dao instances were missed by that wave.

## Why redaction-with-asterisks isn't safe

Length-preserving redaction looks like proper redaction at a glance — the actual password isn't visible — so review tends to wave it through. But the leaked length narrows offline brute-force significantly: search space for a 7-char password is roughly `10^14`, for a 12-char one `10^24`. Combined with the timestamp on each span, an attacker reading traces can correlate password lengths to specific accounts and password-reset events.

The right fix is to omit the field entirely. A clever-redaction variant (random-length stars, hash-of-len) just substitutes one side channel for another.

## What changed

- `internal/dao/pg.credentialsInsert.go` — drop `credentials.password` span attribute, drop unused `strings` import.
- `internal/dao/pg.credentialsUpdatePassword.go` — same.
- Both keep a short comment in place of the dropped line so the omission is discoverable and a future reader doesn't reintroduce the pattern.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -run NONE` (test compilation) clean for affected packages
- [x] No tests asserted on the `credentials.password` span attribute (grep confirms)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)