### PR TITLE
fix(services): keep tokenRefresh claim-check failures on user-facing path

### DIFF
--- a/golangci-lint.sum
+++ b/golangci-lint.sum
@@ -1,0 +1,2 @@
+github.com/golangci/golangci-lint/v2 v2.12.2 h1:7+d1uY0bq1MU2UV3R5pW5Q7QWdcoq4naMRXM+gsJKrs=
+github.com/golangci/golangci-lint/v2 v2.12.2/go.mod h1:opqHHuIcTG2R+4akzWMd4o1BnD9/1LcjICWOujr91U8=

--- a/golangci-lint.sum
+++ b/golangci-lint.sum
@@ -1,2 +1,0 @@
-github.com/golangci/golangci-lint/v2 v2.12.2 h1:7+d1uY0bq1MU2UV3R5pW5Q7QWdcoq4naMRXM+gsJKrs=
-github.com/golangci/golangci-lint/v2 v2.12.2/go.mod h1:opqHHuIcTG2R+4akzWMd4o1BnD9/1LcjICWOujr91U8=

--- a/internal/services/tokenRefresh.go
+++ b/internal/services/tokenRefresh.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/a-novel-kit/golib/grpcf"
 	"github.com/a-novel-kit/golib/otel"
-	"github.com/a-novel-kit/jwt/jws"
 	"github.com/a-novel-kit/jwt/jwp"
+	"github.com/a-novel-kit/jwt/jws"
 
 	"github.com/a-novel/service-authentication/v2/internal/dao"
 )

--- a/internal/services/tokenRefresh.go
+++ b/internal/services/tokenRefresh.go
@@ -13,22 +13,24 @@ import (
 	"github.com/a-novel-kit/golib/grpcf"
 	"github.com/a-novel-kit/golib/otel"
 	"github.com/a-novel-kit/jwt/jws"
+	"github.com/a-novel-kit/jwt/jwp"
 
 	"github.com/a-novel/service-authentication/v2/internal/dao"
 )
 
 var (
 	// ErrTokenRefreshInvalidAccessToken is returned by [TokenRefresh.Exec] when the
-	// access token's signature is invalid. Expiry is intentionally ignored on the
-	// access token (refresh exists precisely to renew an expired one), so this
-	// signals forgery or key rotation, not staleness.
+	// access token fails verification with a user-input failure: a bad signature
+	// (jws.ErrInvalidSignature) or a failed claim check (jwp.ErrInvalidClaims —
+	// audience, issuer, or subject mismatch; expiry is intentionally ignored on the
+	// access token because refresh exists precisely to renew an expired one). The
+	// sentinel is joined onto the underlying verifier error.
 	ErrTokenRefreshInvalidAccessToken = errors.New("invalid access token")
 	// ErrTokenRefreshInvalidRefreshToken is returned by [TokenRefresh.Exec] when
-	// the refresh token's signature is invalid; the sentinel is joined onto the
-	// underlying jws.ErrInvalidSignature error. Other verifier failures
-	// (malformed token, expiry, audience mismatch, etc.) currently surface as
-	// the raw verifier error and are reported on the span as infrastructure
-	// failures rather than user-facing outcomes.
+	// the refresh token fails verification with a user-input failure: a bad
+	// signature (jws.ErrInvalidSignature) or a failed claim check
+	// (jwp.ErrInvalidClaims — expiry, audience, issuer, or subject mismatch).
+	// The sentinel is joined onto the underlying verifier error.
 	ErrTokenRefreshInvalidRefreshToken = errors.New("invalid refresh token")
 	// ErrTokenRefreshMismatchClaims is returned by [TokenRefresh.Exec] when the
 	// access and refresh tokens are individually valid but encode different user
@@ -106,7 +108,7 @@ func (service *TokenRefresh) Exec(
 		},
 	)
 	if err != nil {
-		if errors.Is(err, jws.ErrInvalidSignature) {
+		if errors.Is(err, jws.ErrInvalidSignature) || errors.Is(err, jwp.ErrInvalidClaims) {
 			return nil, errors.Join(err, ErrTokenRefreshInvalidAccessToken)
 		}
 
@@ -123,7 +125,7 @@ func (service *TokenRefresh) Exec(
 		},
 	)
 	if err != nil {
-		if errors.Is(err, jws.ErrInvalidSignature) {
+		if errors.Is(err, jws.ErrInvalidSignature) || errors.Is(err, jwp.ErrInvalidClaims) {
 			return nil, errors.Join(err, ErrTokenRefreshInvalidRefreshToken)
 		}
 

--- a/internal/services/tokenRefresh_test.go
+++ b/internal/services/tokenRefresh_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/a-novel/service-json-keys/v2/pkg/go"
 
 	"github.com/a-novel-kit/golib/grpcf"
-	"github.com/a-novel-kit/jwt/jws"
 	"github.com/a-novel-kit/jwt/jwp"
+	"github.com/a-novel-kit/jwt/jws"
 
 	"github.com/a-novel/service-authentication/v2/internal/dao"
 	"github.com/a-novel/service-authentication/v2/internal/services"

--- a/internal/services/tokenRefresh_test.go
+++ b/internal/services/tokenRefresh_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/a-novel-kit/golib/grpcf"
 	"github.com/a-novel-kit/jwt/jws"
+	"github.com/a-novel-kit/jwt/jwp"
 
 	"github.com/a-novel/service-authentication/v2/internal/dao"
 	"github.com/a-novel/service-authentication/v2/internal/services"
@@ -237,6 +238,46 @@ func TestTokenRefresh(t *testing.T) {
 			},
 
 			expectErr: services.ErrTokenRefreshInvalidAccessToken,
+		},
+		{
+			// Audience/issuer/subject mismatch on the access token surfaces as
+			// jwp.ErrInvalidClaims. (Expiry is ignored on the access token.)
+			name: "InvalidAccessTokenClaims",
+
+			request: &services.TokenRefreshRequest{
+				AccessToken:  base64.RawURLEncoding.EncodeToString([]byte("access-token")),
+				RefreshToken: base64.RawURLEncoding.EncodeToString([]byte("refresh_token")),
+			},
+
+			serviceVerifyClaimsMock: &serviceVerifyClaimsMock{
+				err: jwp.ErrInvalidClaims,
+			},
+
+			expectErr: services.ErrTokenRefreshInvalidAccessToken,
+		},
+		{
+			// Refresh-token expiry, audience, issuer or subject mismatch all
+			// surface through the verifier as jwp.ErrInvalidClaims.
+			name: "InvalidRefreshTokenClaims",
+
+			request: &services.TokenRefreshRequest{
+				AccessToken:  base64.RawURLEncoding.EncodeToString([]byte("access-token")),
+				RefreshToken: base64.RawURLEncoding.EncodeToString([]byte("refresh_token")),
+			},
+
+			serviceVerifyClaimsMock: &serviceVerifyClaimsMock{
+				resp: &services.AccessTokenClaims{
+					UserID:         lo.ToPtr(uuid.MustParse("00000000-0000-0000-0000-000000000001")),
+					Roles:          []string{"admin"},
+					RefreshTokenID: "refresh_token_id",
+				},
+			},
+
+			serviceVerifyRefreshClaimsMock: &serviceVerifyRefreshClaimsMock{
+				err: jwp.ErrInvalidClaims,
+			},
+
+			expectErr: services.ErrTokenRefreshInvalidRefreshToken,
 		},
 
 		{


### PR DESCRIPTION
## Summary

\`TokenRefresh.Exec\` only joined the per-token sentinel (\`ErrTokenRefreshInvalidAccessToken\` / \`ErrTokenRefreshInvalidRefreshToken\`) onto \`jws.ErrInvalidSignature\`. Every other verifier failure — **expired refresh token**, wrong audience, wrong issuer, wrong subject — fell through to \`otel.ReportError\` without the sentinel.

That has two consequences:

1. The span is marked errored on what is really expected user input (an expired refresh token isn't a service failure; the user just needs to re-authenticate). This violates the project's sentinel-vs-span policy (#812 wave fix and the saved-memory feedback note).
2. Callers can't branch on the sentinel for these cases — they hit a generic 500-mapped error path instead of the 401-mapped one, even though the user-supplied token is the cause.

## How

\`github.com/a-novel-kit/jwt/jwp.ClaimsChecker\` wraps every claim-check failure with \`jwp.ErrInvalidClaims\` (verified by reading the upstream source at \`jwp/claims_checker.go:141\`). Catching that sentinel alongside \`jws.ErrInvalidSignature\` on both verifier branches preserves clean-sentinel semantics for user-input failures while still reporting genuine infrastructure failures (json-keys RPC down, malformed gRPC response) on the span.

This is a behavior change: previously, an expired refresh token returned \`error\` not wrapping \`ErrTokenRefreshInvalidRefreshToken\`; now it does. Callers that relied on \`errors.Is(err, ErrTokenRefreshInvalidRefreshToken)\` will start seeing expired-token cases (which they should — that was the intended contract).

## Tests

Two new cases mirror the existing signature-failure tests:

- \`InvalidAccessTokenClaims\` — audience/issuer/subject mismatch on the access token. (Expiry is ignored on access tokens here; refresh exists to renew them.)
- \`InvalidRefreshTokenClaims\` — expiry, audience, issuer, or subject mismatch on the refresh token.

Doc comments on both sentinels updated to describe the broader contract.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test -run TestTokenRefresh ./internal/services/\` passes (existing + two new cases)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)