### PR TITLE
docs(dao): document remaining exported sentinels and request types

### DIFF
--- a/internal/dao/pg.credentialsExist.go
+++ b/internal/dao/pg.credentialsExist.go
@@ -14,7 +14,9 @@ import (
 //go:embed pg.credentialsExist.sql
 var credentialsExistQuery string
 
+// CredentialsExistRequest is the input to [CredentialsExist.Exec].
 type CredentialsExistRequest struct {
+	// Email to check for an existing registration. Comparison is case-sensitive.
 	Email string
 }
 

--- a/internal/dao/pg.credentialsList.go
+++ b/internal/dao/pg.credentialsList.go
@@ -15,10 +15,14 @@ import (
 //go:embed pg.credentialsList.sql
 var credentialsListQuery string
 
+// CredentialsListRequest is the input to [CredentialsList.Exec]. Pagination uses
+// limit/offset; an empty Roles slice disables the role filter and returns
+// credentials of every role.
 type CredentialsListRequest struct {
 	Limit  int
 	Offset int
-	// Filter credentials by role.
+	// Roles, if non-empty, restricts the result to credentials whose role is in
+	// the slice. An empty slice returns credentials of every role.
 	Roles []string
 }
 

--- a/internal/dao/pg.credentialsSelect.go
+++ b/internal/dao/pg.credentialsSelect.go
@@ -17,12 +17,19 @@ import (
 //go:embed pg.credentialsSelect.sql
 var credentialsSelectQuery string
 
+// ErrCredentialsSelectNotFound is returned by [CredentialsSelect.Exec] when no
+// row matches the requested ID. It is joined onto the underlying sql.ErrNoRows
+// so callers can branch on it with errors.Is.
 var ErrCredentialsSelectNotFound = errors.New("credentials not found")
 
+// CredentialsSelectRequest is the input to [CredentialsSelect.Exec].
 type CredentialsSelectRequest struct {
+	// ID of the credentials to fetch.
 	ID uuid.UUID
 }
 
+// CredentialsSelect fetches a single credentials row by ID. Use
+// [CredentialsSelectByEmail] to look up by email instead.
 type CredentialsSelect struct{}
 
 func NewCredentialsSelect() *CredentialsSelect {

--- a/internal/dao/pg.credentialsSelectByEmail.go
+++ b/internal/dao/pg.credentialsSelectByEmail.go
@@ -16,12 +16,20 @@ import (
 //go:embed pg.credentialsSelectByEmail.sql
 var credentialsSelectByEmailQuery string
 
+// ErrCredentialsSelectByEmailNotFound is returned by
+// [CredentialsSelectByEmail.Exec] when no row matches the requested email. It is
+// joined onto the underlying sql.ErrNoRows so callers can branch on it with
+// errors.Is.
 var ErrCredentialsSelectByEmailNotFound = errors.New("credentials not found")
 
+// CredentialsSelectByEmailRequest is the input to [CredentialsSelectByEmail.Exec].
 type CredentialsSelectByEmailRequest struct {
+	// Email of the credentials to fetch. Comparison is case-sensitive.
 	Email string
 }
 
+// CredentialsSelectByEmail fetches a single credentials row by email. Use
+// [CredentialsSelect] to look up by ID instead.
 type CredentialsSelectByEmail struct{}
 
 func NewCredentialsSelectByEmail() *CredentialsSelectByEmail {

--- a/internal/dao/pg.credentialsUpdateEmail.go
+++ b/internal/dao/pg.credentialsUpdateEmail.go
@@ -20,16 +20,27 @@ import (
 var credentialsUpdateEmailQuery string
 
 var (
+	// ErrCredentialsUpdateEmailAlreadyExists is returned by
+	// [CredentialsUpdateEmail.Exec] when the new email is already registered to
+	// another user. It is detected from the Postgres unique-violation SQLSTATE
+	// (23505) and joined onto the driver error so callers can branch on it.
+	// This race can occur when a different account claims the email between
+	// short-code issuance and consumption.
 	ErrCredentialsUpdateEmailAlreadyExists = errors.New("credentials already exists")
-	ErrCredentialsUpdateEmailNotFound      = errors.New("credentials not found")
+	// ErrCredentialsUpdateEmailNotFound is returned by [CredentialsUpdateEmail.Exec]
+	// when no row matches the requested ID. It is joined onto the underlying
+	// sql.ErrNoRows.
+	ErrCredentialsUpdateEmailNotFound = errors.New("credentials not found")
 )
 
+// CredentialsUpdateEmailRequest is the input to [CredentialsUpdateEmail.Exec].
 type CredentialsUpdateEmailRequest struct {
-	// The ID of the credentials to update.
+	// ID of the credentials to update.
 	ID uuid.UUID
-	// The new Email value for the selected credentials.
+	// Email is the new address to assign. Caller must verify ownership (typically
+	// via a short code emailed to this address) before invoking the repository.
 	Email string
-	// Time used as modification date.
+	// Now is the timestamp recorded as the row's update time.
 	Now time.Time
 }
 

--- a/internal/dao/pg.credentialsUpdatePassword.go
+++ b/internal/dao/pg.credentialsUpdatePassword.go
@@ -19,15 +19,22 @@ import (
 //go:embed pg.credentialsUpdatePassword.sql
 var credentialsUpdatePassword string
 
+// ErrCredentialsUpdatePasswordNotFound is returned by
+// [CredentialsUpdatePassword.Exec] when no row matches the requested ID. It is
+// joined onto the underlying sql.ErrNoRows so callers can branch on it with
+// errors.Is.
 var ErrCredentialsUpdatePasswordNotFound = errors.New("credentials not found")
 
+// CredentialsUpdatePasswordRequest is the input to [CredentialsUpdatePassword.Exec].
 type CredentialsUpdatePasswordRequest struct {
-	// The ID of the credentials to update.
+	// ID of the credentials to update.
 	ID uuid.UUID
-	// The new password to use. This value must be securely encrypted using
-	// one-way encryption, so it doesn't get leaked with the database.
+	// Password is the Argon2id hash to persist, not the plaintext. Plaintext
+	// must be hashed by the caller (typically via lib.GenerateArgon2) before
+	// reaching this layer; storing the hash means a database leak does not
+	// reveal usable credentials.
 	Password string
-	// Time used as modification date.
+	// Now is the timestamp recorded as the row's update time.
 	Now time.Time
 }
 

--- a/internal/dao/pg.credentialsUpdateRole.go
+++ b/internal/dao/pg.credentialsUpdateRole.go
@@ -18,14 +18,20 @@ import (
 //go:embed pg.credentialsUpdateRole.sql
 var credentialsUpdateRoleQuery string
 
+// ErrCredentialsUpdateRoleNotFound is returned by [CredentialsUpdateRole.Exec]
+// when no row matches the requested ID. It is joined onto the underlying
+// sql.ErrNoRows so callers can branch on it with errors.Is.
 var ErrCredentialsUpdateRoleNotFound = errors.New("credentials not found")
 
+// CredentialsUpdateRoleRequest is the input to [CredentialsUpdateRole.Exec].
 type CredentialsUpdateRoleRequest struct {
-	// The ID of the credentials to update.
+	// ID of the credentials to update.
 	ID uuid.UUID
-	// The new Role to assign to the selected credentials.
+	// Role is the new role name to assign. The repository does not validate the
+	// value against the configured permission map; that check belongs to the
+	// service layer.
 	Role string
-	// Time used as modification date.
+	// Now is the timestamp recorded as the row's update time.
 	Now time.Time
 }
 

--- a/internal/dao/pg.shortCodeDelete.go
+++ b/internal/dao/pg.shortCodeDelete.go
@@ -29,12 +29,17 @@ const (
 	ShortCodeDeleteConsumed = "key consumed"
 )
 
+// ShortCodeDeleteRequest is the input to [ShortCodeDelete.Exec]. Comment should
+// usually be one of the [ShortCodeDeleteOverride] / [ShortCodeDeleteConsumed]
+// constants, but any value is accepted and persisted on the deleted row for
+// later auditing.
 type ShortCodeDeleteRequest struct {
 	// ID of the short code to delete.
 	ID uuid.UUID
-	// Time used for deletion date.
+	// Now is the timestamp recorded as the row's deletion time.
 	Now time.Time
-	// Indicate a reason for the short code deletion. See ShortCode.DeletedAt.
+	// Comment records the reason for the deletion; persisted on the row's
+	// deleted_comment column. See [ShortCode.DeletedAt] for the lifecycle.
 	Comment string
 }
 

--- a/internal/dao/pg.shortCodeInsert.go
+++ b/internal/dao/pg.shortCodeInsert.go
@@ -20,16 +20,26 @@ import (
 //go:embed pg.shortCodeInsert.sql
 var shortCodeInsertQuery string
 
-// ErrShortCodeInsertAlreadyExists is returned by [ShortCodeInsert.Exec] when an
-// active short code already covers the same (Usage, Target) pair and Override
-// is false. Set [ShortCodeInsertRequest.Override] to true to retire the existing
-// code (with the [ShortCodeDeleteOverride] comment) and insert the new one in
-// the same transaction.
+// ErrShortCodeInsertAlreadyExists is returned by [ShortCodeInsert.Exec] when
+// the conflict-check query observes an active short code for the same
+// (Usage, Target) pair and Override is false. Set
+// [ShortCodeInsertRequest.Override] to true to retire the existing code (with
+// the [ShortCodeDeleteOverride] comment) and insert the new one in the same
+// transaction.
+//
+// The schema does not declare a unique constraint on (target, usage), and the
+// conflict check is a plain SELECT (not SELECT ... FOR UPDATE), so two
+// transactions racing on the same pair can both observe no conflict and both
+// insert; this sentinel does not protect against that race.
 var ErrShortCodeInsertAlreadyExists = errors.New("short code already exists")
 
 // ShortCodeInsertRequest is the input to [ShortCodeInsert.Exec]. The repository
-// runs at REPEATABLE READ isolation so the conflict check and the insert are
-// atomic with respect to concurrent inserts on the same (Usage, Target) pair.
+// runs at REPEATABLE READ isolation, which gives each transaction a stable
+// snapshot of the table, but the conflict check and the insert are not
+// lock-protected. Concurrent inserts on the same (Usage, Target) pair can
+// both pass the check and both succeed — uniqueness is not guaranteed by the
+// dao layer today. Callers that need it must serialize at a higher level or
+// accept that duplicates may briefly exist.
 type ShortCodeInsertRequest struct {
 	// See ShortCode.ID.
 	ID uuid.UUID

--- a/internal/dao/pg.shortCodeInsert.go
+++ b/internal/dao/pg.shortCodeInsert.go
@@ -20,8 +20,16 @@ import (
 //go:embed pg.shortCodeInsert.sql
 var shortCodeInsertQuery string
 
+// ErrShortCodeInsertAlreadyExists is returned by [ShortCodeInsert.Exec] when an
+// active short code already covers the same (Usage, Target) pair and Override
+// is false. Set [ShortCodeInsertRequest.Override] to true to retire the existing
+// code (with the [ShortCodeDeleteOverride] comment) and insert the new one in
+// the same transaction.
 var ErrShortCodeInsertAlreadyExists = errors.New("short code already exists")
 
+// ShortCodeInsertRequest is the input to [ShortCodeInsert.Exec]. The repository
+// runs at REPEATABLE READ isolation so the conflict check and the insert are
+// atomic with respect to concurrent inserts on the same (Usage, Target) pair.
 type ShortCodeInsertRequest struct {
 	// See ShortCode.ID.
 	ID uuid.UUID

--- a/internal/dao/pg.shortCodeSelect.go
+++ b/internal/dao/pg.shortCodeSelect.go
@@ -16,13 +16,26 @@ import (
 //go:embed pg.shortCodeSelect.sql
 var shortCodeSelectQuery string
 
+// ErrShortCodeSelectNotFound is returned by [ShortCodeSelect.Exec] when no
+// active short code matches the (Usage, Target) pair. Expired or deleted codes
+// are filtered out by the underlying SQL view, so this includes the
+// "code expired" and "code already consumed" cases — callers cannot distinguish
+// them from the dao layer.
 var ErrShortCodeSelectNotFound = errors.New("short code not found")
 
+// ShortCodeSelectRequest is the input to [ShortCodeSelect.Exec]. Usage and
+// Target are jointly unique among active short codes, so the pair selects at
+// most one row.
 type ShortCodeSelectRequest struct {
-	Usage  string
+	// Usage selects which flow this code is valid for; matches [ShortCode.Usage].
+	Usage string
+	// Target identifies the subject of the operation (e.g. the email address);
+	// matches [ShortCode.Target].
 	Target string
 }
 
+// ShortCodeSelect fetches the single active short code matching a (Usage, Target)
+// pair, if any.
 type ShortCodeSelect struct{}
 
 func NewShortCodeSelect() *ShortCodeSelect {

--- a/internal/dao/pg.shortCodeSelect.go
+++ b/internal/dao/pg.shortCodeSelect.go
@@ -17,15 +17,18 @@ import (
 var shortCodeSelectQuery string
 
 // ErrShortCodeSelectNotFound is returned by [ShortCodeSelect.Exec] when no
-// active short code matches the (Usage, Target) pair. Expired or deleted codes
-// are filtered out by the underlying SQL view, so this includes the
-// "code expired" and "code already consumed" cases — callers cannot distinguish
-// them from the dao layer.
+// active short code matches the (Usage, Target) pair. The query filters expired
+// and deleted rows directly in its WHERE clause (deleted_at IS NULL AND
+// expires_at > CURRENT_TIMESTAMP), so this sentinel covers three on-disk states
+// the dao layer can't distinguish: never-issued, expired, and already-consumed.
 var ErrShortCodeSelectNotFound = errors.New("short code not found")
 
-// ShortCodeSelectRequest is the input to [ShortCodeSelect.Exec]. Usage and
-// Target are jointly unique among active short codes, so the pair selects at
-// most one row.
+// ShortCodeSelectRequest is the input to [ShortCodeSelect.Exec]. The application
+// flow assumes at most one active short code exists per (Usage, Target) pair,
+// but the database does not enforce this — only a non-unique index is in place
+// and [ShortCodeInsert] guards duplicates with a check-then-insert that is racy
+// under concurrent writes (see [ShortCodeInsert] for details). When duplicates
+// exist, this query returns whichever row Postgres surfaces first.
 type ShortCodeSelectRequest struct {
 	// Usage selects which flow this code is valid for; matches [ShortCode.Usage].
 	Usage string
@@ -34,8 +37,8 @@ type ShortCodeSelectRequest struct {
 	Target string
 }
 
-// ShortCodeSelect fetches the single active short code matching a (Usage, Target)
-// pair, if any.
+// ShortCodeSelect fetches an active short code matching a (Usage, Target) pair,
+// if any.
 type ShortCodeSelect struct{}
 
 func NewShortCodeSelect() *ShortCodeSelect {


### PR DESCRIPTION
## Summary

Second-pass doc work over the dao package, covering symbols that were exported with no godoc:

- Every "not found" / "already exists" sentinel now documents the condition that returns it, the underlying error it's joined onto (\`sql.ErrNoRows\` for not-found, pgdriver SQLSTATE 23505 for unique violations), and how callers should branch on it with \`errors.Is\`.
- Every request struct gets a type-level doc per the document-code skill: type doc explains the whole, field docs explain individual fields.
- Three repository structs (\`CredentialsSelect\`, \`CredentialsSelectByEmail\`, \`ShortCodeSelect\`) that previously had no doc now have one.

## Drive-by accuracy fix

\`CredentialsUpdatePasswordRequest.Password\` was documented as "must be securely encrypted using one-way encryption". That phrase conflates two distinct primitives: encryption is reversible, hashing is not. The field actually stores the Argon2id hash produced by \`lib.GenerateArgon2\` — confusing a future reader on a security-relevant field is exactly the kind of doc rot worth fixing on contact. Reworded to "the Argon2id hash to persist, not the plaintext".

## Notable: ShortCodeSelect's "not found" is overloaded

The \`ShortCodeSelect\` SQL view filters expired and deleted rows, so \`ErrShortCodeSelectNotFound\` actually covers three on-disk states the dao layer can't distinguish: never-issued, expired, and already-consumed. Documented this so service-layer callers can decide whether they need a more granular signal or whether one error message ("invalid or expired short code") is enough.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test -run NONE ./internal/dao/...\` (test compilation) clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)