### PR TITLE
fix(dao): close ShortCodeInsert race via partial unique index

### DIFF
--- a/internal/dao/pg.shortCodeInsert.discardConflict.sql
+++ b/internal/dao/pg.shortCodeInsert.discardConflict.sql
@@ -8,5 +8,4 @@ WHERE
   AND (
     deleted_at IS NULL
     OR deleted_at > CURRENT_TIMESTAMP
-  )
-  AND expires_at > CURRENT_TIMESTAMP;
+  );

--- a/internal/dao/pg.shortCodeInsert.discardExpired.sql
+++ b/internal/dao/pg.shortCodeInsert.discardExpired.sql
@@ -1,0 +1,9 @@
+UPDATE short_codes
+SET
+  deleted_at = ?0,
+  deleted_comment = ?1
+WHERE
+  target = ?2
+  AND usage = ?3
+  AND deleted_at IS NULL
+  AND expires_at <= ?0;

--- a/internal/dao/pg.shortCodeInsert.go
+++ b/internal/dao/pg.shortCodeInsert.go
@@ -80,18 +80,21 @@ func (repository *ShortCodeInsert) Exec(ctx context.Context, request *ShortCodeI
 	txOptions := &sql.TxOptions{Isolation: sql.LevelRepeatableRead}
 
 	err := postgres.RunInTx(ctx, txOptions, func(ctx context.Context, tx bun.IDB) error {
-		// Soft-delete any naturally-expired-but-not-yet-deleted row first, on
-		// both paths. Without this, the partial unique index
-		// (target, usage) WHERE deleted_at IS NULL would block a fresh insert
-		// against an expired stale row that discardConflicts (Override=true) or
-		// checkConflicts (Override=false) would otherwise ignore — both queries
-		// gate on `expires_at > now()`, so naturally-expired rows are invisible
-		// to them but still live in the partial index.
-		err := repository.discardExpired(ctx, tx, request)
-		if err == nil {
-			if request.Override {
-				err = repository.discardConflicts(ctx, tx, request)
-			} else {
+		var err error
+
+		if request.Override {
+			// Retire every not-yet-effectively-deleted row for the pair in a
+			// single UPDATE — active and naturally expired alike — so the
+			// partial unique index (target, usage) WHERE deleted_at IS NULL is
+			// clear before the insert.
+			err = repository.discardConflicts(ctx, tx, request)
+		} else {
+			// checkConflicts gates on `expires_at > now()`, so a naturally
+			// expired but not-yet-deleted row is invisible to it — yet that row
+			// still lives in the partial unique index and would make the insert
+			// fail with a unique violation. Soft-delete it first.
+			err = repository.discardExpired(ctx, tx, request)
+			if err == nil {
 				err = repository.checkConflicts(ctx, tx, request)
 			}
 		}
@@ -143,13 +146,11 @@ func (repository *ShortCodeInsert) discardConflicts(
 
 	_, err := tx.NewRaw(
 		shortCodeInsertDiscardConflictQuery,
-		// So as we switch between Go/Pg timestamps, and transactions / views / triggers,
-		// there is a mismatch when comparing dates which can sometimes lead Postgres to
-		// believe this (expired) row is still part of the active short codes view.
-		//
-		// To make sure any conflicting short code is considered expired by the time
-		// we perform the insertion, we cheat and make the deletion date one second
-		// older. This is usually enough to prevent any issue.
+		// Go and Postgres can disagree on "now" by a small margin across the
+		// driver/connection boundary; backdating the deletion timestamp by one
+		// second keeps the row firmly in the past for any later predicate that
+		// compares deleted_at against CURRENT_TIMESTAMP (e.g. the active
+		// short-codes view), so it never re-surfaces as active.
 		lo.ToPtr(request.Now.Add(-time.Second)),
 		lo.ToPtr(ShortCodeDeleteOverride),
 		request.Target,

--- a/internal/dao/pg.shortCodeInsert.go
+++ b/internal/dao/pg.shortCodeInsert.go
@@ -80,20 +80,18 @@ func (repository *ShortCodeInsert) Exec(ctx context.Context, request *ShortCodeI
 	txOptions := &sql.TxOptions{Isolation: sql.LevelRepeatableRead}
 
 	err := postgres.RunInTx(ctx, txOptions, func(ctx context.Context, tx bun.IDB) error {
-		var err error
-
-		if request.Override {
-			err = repository.discardConflicts(ctx, tx, request)
-		} else {
-			// Soft-delete any naturally-expired-but-not-yet-deleted row first.
-			// Without this, the partial unique index (target, usage) WHERE
-			// deleted_at IS NULL would block a fresh insert against an expired
-			// stale row, even though the application contract is that expired
-			// codes don't reserve their slot. With this, the active-conflict
-			// check below sees a clean slate and the index only fires on real
-			// active conflicts.
-			err = repository.discardExpired(ctx, tx, request)
-			if err == nil {
+		// Soft-delete any naturally-expired-but-not-yet-deleted row first, on
+		// both paths. Without this, the partial unique index
+		// (target, usage) WHERE deleted_at IS NULL would block a fresh insert
+		// against an expired stale row that discardConflicts (Override=true) or
+		// checkConflicts (Override=false) would otherwise ignore — both queries
+		// gate on `expires_at > now()`, so naturally-expired rows are invisible
+		// to them but still live in the partial index.
+		err := repository.discardExpired(ctx, tx, request)
+		if err == nil {
+			if request.Override {
+				err = repository.discardConflicts(ctx, tx, request)
+			} else {
 				err = repository.checkConflicts(ctx, tx, request)
 			}
 		}

--- a/internal/dao/pg.shortCodeInsert.go
+++ b/internal/dao/pg.shortCodeInsert.go
@@ -21,17 +21,6 @@ import (
 //go:embed pg.shortCodeInsert.sql
 var shortCodeInsertQuery string
 
-// ErrShortCodeInsertAlreadyExists is returned by [ShortCodeInsert.Exec] when
-// the conflict-check query observes an active short code for the same
-// (Usage, Target) pair and Override is false. Set
-// [ShortCodeInsertRequest.Override] to true to retire the existing code (with
-// the [ShortCodeDeleteOverride] comment) and insert the new one in the same
-// transaction.
-//
-// The schema does not declare a unique constraint on (target, usage), and the
-// conflict check is a plain SELECT (not SELECT ... FOR UPDATE), so two
-// transactions racing on the same pair can both observe no conflict and both
-// insert; this sentinel does not protect against that race.
 // ErrShortCodeInsertAlreadyExists is returned by [ShortCodeInsert.Exec] when an
 // active short code already covers the same (target, usage) pair. Detection
 // runs in two layers: an in-transaction conflict check on the Override=false
@@ -43,12 +32,10 @@ var shortCodeInsertQuery string
 var ErrShortCodeInsertAlreadyExists = errors.New("short code already exists")
 
 // ShortCodeInsertRequest is the input to [ShortCodeInsert.Exec]. The repository
-// runs at REPEATABLE READ isolation, which gives each transaction a stable
-// snapshot of the table, but the conflict check and the insert are not
-// lock-protected. Concurrent inserts on the same (Usage, Target) pair can
-// both pass the check and both succeed — uniqueness is not guaranteed by the
-// dao layer today. Callers that need it must serialize at a higher level or
-// accept that duplicates may briefly exist.
+// runs at REPEATABLE READ isolation; uniqueness on (target, usage) for the
+// active subset is enforced by the partial unique index added in the
+// 20260510140000 migration, so concurrent inserts cannot produce duplicates
+// (the loser sees [ErrShortCodeInsertAlreadyExists]).
 type ShortCodeInsertRequest struct {
 	// See ShortCode.ID.
 	ID uuid.UUID
@@ -98,7 +85,17 @@ func (repository *ShortCodeInsert) Exec(ctx context.Context, request *ShortCodeI
 		if request.Override {
 			err = repository.discardConflicts(ctx, tx, request)
 		} else {
-			err = repository.checkConflicts(ctx, tx, request)
+			// Soft-delete any naturally-expired-but-not-yet-deleted row first.
+			// Without this, the partial unique index (target, usage) WHERE
+			// deleted_at IS NULL would block a fresh insert against an expired
+			// stale row, even though the application contract is that expired
+			// codes don't reserve their slot. With this, the active-conflict
+			// check below sees a clean slate and the index only fires on real
+			// active conflicts.
+			err = repository.discardExpired(ctx, tx, request)
+			if err == nil {
+				err = repository.checkConflicts(ctx, tx, request)
+			}
 		}
 
 		if err != nil {
@@ -157,6 +154,31 @@ func (repository *ShortCodeInsert) discardConflicts(
 		// older. This is usually enough to prevent any issue.
 		lo.ToPtr(request.Now.Add(-time.Second)),
 		lo.ToPtr(ShortCodeDeleteOverride),
+		request.Target,
+		request.Usage,
+	).Exec(ctx)
+	if err != nil {
+		return otel.ReportError(span, fmt.Errorf("execute query: %w", err))
+	}
+
+	otel.ReportSuccessNoContent(span)
+
+	return nil
+}
+
+//go:embed pg.shortCodeInsert.discardExpired.sql
+var shortCodeInsertDiscardExpiredQuery string
+
+func (repository *ShortCodeInsert) discardExpired(
+	ctx context.Context, tx bun.IDB, request *ShortCodeInsertRequest,
+) error {
+	ctx, span := otel.Tracer().Start(ctx, "dao.ShortCodeInsert(discardExpired)")
+	defer span.End()
+
+	_, err := tx.NewRaw(
+		shortCodeInsertDiscardExpiredQuery,
+		request.Now,
+		"expired before insert",
 		request.Target,
 		request.Usage,
 	).Exec(ctx)

--- a/internal/dao/pg.shortCodeInsert.go
+++ b/internal/dao/pg.shortCodeInsert.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/driver/pgdriver"
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/a-novel-kit/golib/otel"
@@ -31,6 +32,14 @@ var shortCodeInsertQuery string
 // conflict check is a plain SELECT (not SELECT ... FOR UPDATE), so two
 // transactions racing on the same pair can both observe no conflict and both
 // insert; this sentinel does not protect against that race.
+// ErrShortCodeInsertAlreadyExists is returned by [ShortCodeInsert.Exec] when an
+// active short code already covers the same (target, usage) pair. Detection
+// runs in two layers: an in-transaction conflict check on the Override=false
+// path that short-circuits with this sentinel, and the database's partial
+// unique index (target, usage) WHERE deleted_at IS NULL, which catches any
+// race that slips past the check by mapping the resulting SQLSTATE 23505 onto
+// the same sentinel. Callers branch on it with errors.Is regardless of which
+// layer caught the conflict.
 var ErrShortCodeInsertAlreadyExists = errors.New("short code already exists")
 
 // ShortCodeInsertRequest is the input to [ShortCodeInsert.Exec]. The repository
@@ -107,6 +116,15 @@ func (repository *ShortCodeInsert) Exec(ctx context.Context, request *ShortCodeI
 			request.ExpiresAt,
 		).Scan(ctx, entity)
 		if err != nil {
+			// The partial unique index (target, usage) WHERE deleted_at IS NULL
+			// catches any conflict that the in-transaction check missed under
+			// concurrent inserts. Map the SQLSTATE 23505 onto the same sentinel
+			// callers already use so they don't need to distinguish the layer.
+			var pgErr pgdriver.Error
+			if errors.As(err, &pgErr) && pgErr.Field('C') == "23505" {
+				err = errors.Join(err, ErrShortCodeInsertAlreadyExists)
+			}
+
 			return fmt.Errorf("execute query: %w", err)
 		}
 

--- a/internal/dao/pg.shortCodeSelect.go
+++ b/internal/dao/pg.shortCodeSelect.go
@@ -23,12 +23,10 @@ var shortCodeSelectQuery string
 // the dao layer can't distinguish: never-issued, expired, and already-consumed.
 var ErrShortCodeSelectNotFound = errors.New("short code not found")
 
-// ShortCodeSelectRequest is the input to [ShortCodeSelect.Exec]. The application
-// flow assumes at most one active short code exists per (Usage, Target) pair,
-// but the database does not enforce this — only a non-unique index is in place
-// and [ShortCodeInsert] guards duplicates with a check-then-insert that is racy
-// under concurrent writes (see [ShortCodeInsert] for details). When duplicates
-// exist, this query returns whichever row Postgres surfaces first.
+// ShortCodeSelectRequest is the input to [ShortCodeSelect.Exec]. At most one
+// non-deleted row exists per (Usage, Target) pair: the partial unique index
+// added in the 20260510140000 migration enforces this, so the query returns
+// either zero or one row.
 type ShortCodeSelectRequest struct {
 	// Usage selects which flow this code is valid for; matches [ShortCode.Usage].
 	Usage string

--- a/internal/models/migrations/20260510140000_short_codes_active_unique.down.sql
+++ b/internal/models/migrations/20260510140000_short_codes_active_unique.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS short_codes_active_target_usage_uniq;

--- a/internal/models/migrations/20260510140000_short_codes_active_unique.up.sql
+++ b/internal/models/migrations/20260510140000_short_codes_active_unique.up.sql
@@ -9,21 +9,35 @@ row per (target, usage) is kept; older duplicates are marked deleted with a
 distinct comment so they're auditable. In a healthy deployment this affects
 zero rows.
 */
-WITH ranked AS (
-  SELECT
-    id,
-    ROW_NUMBER() OVER (
-      PARTITION BY target, usage
-      ORDER BY created_at DESC
-    ) AS rank
-  FROM short_codes
-  WHERE deleted_at IS NULL
-)
+WITH
+  ranked AS (
+    SELECT
+      id,
+      ROW_NUMBER() OVER (
+        PARTITION BY
+          target,
+          usage
+        ORDER BY
+          created_at DESC
+      ) AS rank
+    FROM
+      short_codes
+    WHERE
+      deleted_at IS NULL
+  )
 UPDATE short_codes
 SET
   deleted_at = CURRENT_TIMESTAMP,
   deleted_comment = 'duplicate cleanup before unique index'
-WHERE id IN (SELECT id FROM ranked WHERE rank > 1);
+WHERE
+  id IN (
+    SELECT
+      id
+    FROM
+      ranked
+    WHERE
+      rank > 1
+  );
 
 /*
 Postgres requires partial-index predicates to be IMMUTABLE, so the predicate
@@ -35,6 +49,6 @@ deleted rows are still in the partial index, but a subsequent insert with
 Override=true will mark them deleted before its own insert, so the
 constraint isn't a barrier in any production path.
 */
-CREATE UNIQUE INDEX short_codes_active_target_usage_uniq
-  ON short_codes (target, usage)
-  WHERE deleted_at IS NULL;
+CREATE UNIQUE INDEX short_codes_active_target_usage_uniq ON short_codes (target, usage)
+WHERE
+  deleted_at IS NULL;

--- a/internal/models/migrations/20260510140000_short_codes_active_unique.up.sql
+++ b/internal/models/migrations/20260510140000_short_codes_active_unique.up.sql
@@ -18,7 +18,8 @@ WITH
           target,
           usage
         ORDER BY
-          created_at DESC
+          created_at DESC,
+          id DESC
       ) AS rank
     FROM
       short_codes
@@ -42,12 +43,10 @@ WHERE
 /*
 Postgres requires partial-index predicates to be IMMUTABLE, so the predicate
 can't include `expires_at > now()` directly. The (deleted_at IS NULL) form
-covers concurrent active inserts because every production caller passes
-Override=true on ShortCodeInsert, which always sets deleted_at on
-pre-existing matching rows before inserting. Naturally-expired-but-not-yet-
-deleted rows are still in the partial index, but a subsequent insert with
-Override=true will mark them deleted before its own insert, so the
-constraint isn't a barrier in any production path.
+covers active conflicts; naturally-expired-but-not-yet-deleted rows are also
+in the partial index, but the dao always runs a discardExpired soft-delete
+step before either the Override=true or Override=false conflict path, so
+those stale rows never block a fresh insert.
 */
 CREATE UNIQUE INDEX short_codes_active_target_usage_uniq ON short_codes (target, usage)
 WHERE

--- a/internal/models/migrations/20260510140000_short_codes_active_unique.up.sql
+++ b/internal/models/migrations/20260510140000_short_codes_active_unique.up.sql
@@ -1,0 +1,40 @@
+/*
+Close the (target, usage) race in ShortCodeInsert by enforcing at the
+database level what the application has always intended: at most one
+non-deleted short code per (target, usage) pair.
+
+Pre-cleanup soft-deletes any duplicate active rows the racy check-then-insert
+may have introduced before the constraint can be applied. The most recent
+row per (target, usage) is kept; older duplicates are marked deleted with a
+distinct comment so they're auditable. In a healthy deployment this affects
+zero rows.
+*/
+WITH ranked AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY target, usage
+      ORDER BY created_at DESC
+    ) AS rank
+  FROM short_codes
+  WHERE deleted_at IS NULL
+)
+UPDATE short_codes
+SET
+  deleted_at = CURRENT_TIMESTAMP,
+  deleted_comment = 'duplicate cleanup before unique index'
+WHERE id IN (SELECT id FROM ranked WHERE rank > 1);
+
+/*
+Postgres requires partial-index predicates to be IMMUTABLE, so the predicate
+can't include `expires_at > now()` directly. The (deleted_at IS NULL) form
+covers concurrent active inserts because every production caller passes
+Override=true on ShortCodeInsert, which always sets deleted_at on
+pre-existing matching rows before inserting. Naturally-expired-but-not-yet-
+deleted rows are still in the partial index, but a subsequent insert with
+Override=true will mark them deleted before its own insert, so the
+constraint isn't a barrier in any production path.
+*/
+CREATE UNIQUE INDEX short_codes_active_target_usage_uniq
+  ON short_codes (target, usage)
+  WHERE deleted_at IS NULL;


### PR DESCRIPTION
## Summary

Closes the (target, usage) race documented (and resolved as a known limitation) in #847. The dao layer now has the database itself as the authoritative race guard; concurrent inserts that slip past the in-transaction check are mapped onto the existing `ErrShortCodeInsertAlreadyExists` sentinel.

## What changed

1. **New migration `20260510140000_short_codes_active_unique`**
   - Pre-cleanup: soft-deletes any pre-existing duplicate active rows (keeps the most-recently-created per pair, marks older with a distinct `deleted_comment` for auditing). In a healthy deployment this affects zero rows.
   - `CREATE UNIQUE INDEX short_codes_active_target_usage_uniq ON short_codes (target, usage) WHERE deleted_at IS NULL;`
2. **`pg.shortCodeInsert.go`**
   - On `INSERT` failure, parse the pgdriver error: SQLSTATE `23505` (unique violation) → join `ErrShortCodeInsertAlreadyExists`. Mirrors the pattern already used in `pg.credentialsInsert.go`.
   - `Override=true` path: a single `discardConflicts` UPDATE now retires *every* not-yet-effectively-deleted row for the pair — active and naturally expired alike (the old `expires_at > now()` filter on that query was dropped). The common path is therefore back to two statements (discard + insert) instead of three, and a clock-skew window — a row expiring between the Go-captured `Now` and the Postgres `CURRENT_TIMESTAMP`, caught by neither the old `discardExpired` nor `discardConflicts` — that could otherwise make the insert fail with a spurious unique violation is closed.
   - `Override=false` path: a `discardExpired` UPDATE soft-deletes any naturally-expired-but-not-yet-deleted row before `checkConflicts` runs. `checkConflicts` gates on `expires_at > now()`, so it ignores such a row, but the row still lives in the partial index and would otherwise make the insert fail; an unconditional delete is not an option here since the caller explicitly asked not to clobber an active code.
   - Doc on the sentinel rewritten to describe the two-layer detection (in-transaction check + database-enforced index).

## Why partial unique on `deleted_at IS NULL` (not `AND expires_at > now()`)

Postgres requires partial-index predicates to be IMMUTABLE, so `now()`/`CURRENT_TIMESTAMP` cannot appear in a partial index. The `(deleted_at IS NULL)` form is sufficient in practice because the dao always retires the matching not-deleted row(s) before the insert — unconditionally on the `Override=true` path (every production caller: `shortCodeCreateRegister`, `shortCodeCreatePasswordReset`, `shortCodeCreateEmailUpdate`), and via `discardExpired` + `checkConflicts` on the `Override=false` path. Naturally-expired-but-not-yet-deleted rows are therefore short-lived in any flow and never block a fresh insert.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -run NONE` (test compilation) clean for affected packages
- [ ] CI (will exercise the migration end-to-end via the standalone test image, which runs migrations on startup)

## Coordination with #847

#847 (still open) added doc text to `pg.shortCodeInsert.go` and `pg.shortCodeSelect.go` describing the race as a known limitation. Once #847 lands, those doc strings become stale — this PR will conflict on the doc text and the resolution is to take this PR's wording (which describes the now-enforced guarantee). Easy reconcile either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
