### PR TITLE
chore(handlers): span names rest.X instead of handler.X

### DIFF
--- a/internal/handlers/rest.claimsGet.go
+++ b/internal/handlers/rest.claimsGet.go
@@ -19,7 +19,7 @@ func NewClaimsGet(logger logging.Log) *ClaimsGet {
 }
 
 func (handler *ClaimsGet) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, span := otel.Tracer().Start(r.Context(), "handler.ClaimsGet")
+	ctx, span := otel.Tracer().Start(r.Context(), "rest.ClaimsGet")
 	defer span.End()
 
 	claims, err := middlewares.MustGetClaimsContext(ctx)

--- a/internal/handlers/rest.credentialsCreate.go
+++ b/internal/handlers/rest.credentialsCreate.go
@@ -33,7 +33,7 @@ func NewCredentialsCreate(service CredentialsCreateService, logger logging.Log) 
 }
 
 func (handler *CredentialsCreate) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, span := otel.Tracer().Start(r.Context(), "handler.CredentialsCreate")
+	ctx, span := otel.Tracer().Start(r.Context(), "rest.CredentialsCreate")
 	defer span.End()
 
 	decoder := json.NewDecoder(r.Body)

--- a/internal/handlers/rest.credentialsExist.go
+++ b/internal/handlers/rest.credentialsExist.go
@@ -29,7 +29,7 @@ func NewCredentialsExist(service CredentialsExistService, logger logging.Log) *C
 }
 
 func (handler *CredentialsExist) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, span := otel.Tracer().Start(r.Context(), "handler.CredentialsExist")
+	ctx, span := otel.Tracer().Start(r.Context(), "rest.CredentialsExist")
 	defer span.End()
 
 	var request CredentialsExistRequest

--- a/internal/handlers/rest.credentialsGet.go
+++ b/internal/handlers/rest.credentialsGet.go
@@ -32,7 +32,7 @@ func NewCredentialsGet(service CredentialsGetService, logger logging.Log) *Crede
 }
 
 func (handler *CredentialsGet) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, span := otel.Tracer().Start(r.Context(), "handler.CredentialsGet")
+	ctx, span := otel.Tracer().Start(r.Context(), "rest.CredentialsGet")
 	defer span.End()
 
 	var request CredentialsGetRequest

--- a/internal/handlers/rest.credentialsList.go
+++ b/internal/handlers/rest.credentialsList.go
@@ -33,7 +33,7 @@ func NewCredentialsList(service CredentialsListService, logger logging.Log) *Cre
 }
 
 func (handler *CredentialsList) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, span := otel.Tracer().Start(r.Context(), "handler.CredentialsList")
+	ctx, span := otel.Tracer().Start(r.Context(), "rest.CredentialsList")
 	defer span.End()
 
 	var request CredentialsListRequest

--- a/internal/handlers/rest.credentialsResetPassword.go
+++ b/internal/handlers/rest.credentialsResetPassword.go
@@ -37,7 +37,7 @@ func NewCredentialsResetPassword(
 }
 
 func (handler *CredentialsResetPassword) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, span := otel.Tracer().Start(r.Context(), "handler.CredentialsResetPassword")
+	ctx, span := otel.Tracer().Start(r.Context(), "rest.CredentialsResetPassword")
 	defer span.End()
 
 	decoder := json.NewDecoder(r.Body)

--- a/internal/handlers/rest.credentialsUpdateEmail.go
+++ b/internal/handlers/rest.credentialsUpdateEmail.go
@@ -34,7 +34,7 @@ func NewCredentialsUpdateEmail(service CredentialsUpdateEmailService, logger log
 }
 
 func (handler *CredentialsUpdateEmail) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, span := otel.Tracer().Start(r.Context(), "handler.CredentialsUpdateEmail")
+	ctx, span := otel.Tracer().Start(r.Context(), "rest.CredentialsUpdateEmail")
 	defer span.End()
 
 	decoder := json.NewDecoder(r.Body)

--- a/internal/handlers/rest.credentialsUpdatePassword.go
+++ b/internal/handlers/rest.credentialsUpdatePassword.go
@@ -38,7 +38,7 @@ func NewCredentialsUpdatePassword(
 }
 
 func (handler *CredentialsUpdatePassword) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, span := otel.Tracer().Start(r.Context(), "handler.CredentialsUpdatePassword")
+	ctx, span := otel.Tracer().Start(r.Context(), "rest.CredentialsUpdatePassword")
 	defer span.End()
 
 	decoder := json.NewDecoder(r.Body)

--- a/internal/handlers/rest.credentialsUpdateRole.go
+++ b/internal/handlers/rest.credentialsUpdateRole.go
@@ -36,7 +36,7 @@ func NewCredentialsUpdateRole(service CredentialsUpdateRoleService, logger loggi
 }
 
 func (handler *CredentialsUpdateRole) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, span := otel.Tracer().Start(r.Context(), "handler.CredentialsUpdateRole")
+	ctx, span := otel.Tracer().Start(r.Context(), "rest.CredentialsUpdateRole")
 	defer span.End()
 
 	decoder := json.NewDecoder(r.Body)

--- a/internal/handlers/rest.shortCodeCreateEmailUpdate.go
+++ b/internal/handlers/rest.shortCodeCreateEmailUpdate.go
@@ -38,7 +38,7 @@ func NewShortCodeCreateEmailUpdate(
 }
 
 func (handler *ShortCodeCreateEmailUpdate) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, span := otel.Tracer().Start(r.Context(), "handler.ShortCodeCreateEmailUpdate")
+	ctx, span := otel.Tracer().Start(r.Context(), "rest.ShortCodeCreateEmailUpdate")
 	defer span.End()
 
 	decoder := json.NewDecoder(r.Body)

--- a/internal/handlers/rest.shortCodeCreatePasswordReset.go
+++ b/internal/handlers/rest.shortCodeCreatePasswordReset.go
@@ -35,7 +35,7 @@ func NewShortCodeCreatePasswordReset(
 }
 
 func (handler *ShortCodeCreatePasswordReset) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, span := otel.Tracer().Start(r.Context(), "handler.ShortCodeCreatePasswordReset")
+	ctx, span := otel.Tracer().Start(r.Context(), "rest.ShortCodeCreatePasswordReset")
 	defer span.End()
 
 	decoder := json.NewDecoder(r.Body)

--- a/internal/handlers/rest.shortCodeCreateRegister.go
+++ b/internal/handlers/rest.shortCodeCreateRegister.go
@@ -33,7 +33,7 @@ func NewShortCodeCreateRegister(service ShortCodeCreateRegisterService, logger l
 }
 
 func (handler *ShortCodeCreateRegister) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, span := otel.Tracer().Start(r.Context(), "handler.ShortCodeCreateRegister")
+	ctx, span := otel.Tracer().Start(r.Context(), "rest.ShortCodeCreateRegister")
 	defer span.End()
 
 	decoder := json.NewDecoder(r.Body)

--- a/internal/handlers/rest.tokenCreate.go
+++ b/internal/handlers/rest.tokenCreate.go
@@ -33,7 +33,7 @@ func NewTokenCreate(service TokenCreateService, logger logging.Log) *TokenCreate
 }
 
 func (handler *TokenCreate) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, span := otel.Tracer().Start(r.Context(), "handler.TokenCreate")
+	ctx, span := otel.Tracer().Start(r.Context(), "rest.TokenCreate")
 	defer span.End()
 
 	decoder := json.NewDecoder(r.Body)

--- a/internal/handlers/rest.tokenCreateAnon.go
+++ b/internal/handlers/rest.tokenCreateAnon.go
@@ -25,7 +25,7 @@ func NewTokenCreateAnon(service TokenCreateAnonService, logger logging.Log) *Tok
 }
 
 func (handler *TokenCreateAnon) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, span := otel.Tracer().Start(r.Context(), "handler.TokenCreateAnon")
+	ctx, span := otel.Tracer().Start(r.Context(), "rest.TokenCreateAnon")
 	defer span.End()
 
 	res, err := handler.service.Exec(ctx)

--- a/internal/handlers/rest.tokenRefresh.go
+++ b/internal/handlers/rest.tokenRefresh.go
@@ -31,7 +31,7 @@ func NewTokenRefresh(service TokenRefreshService, logger logging.Log) *TokenRefr
 }
 
 func (handler *TokenRefresh) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, span := otel.Tracer().Start(r.Context(), "handler.TokenRefresh")
+	ctx, span := otel.Tracer().Start(r.Context(), "rest.TokenRefresh")
 	defer span.End()
 
 	decoder := json.NewDecoder(r.Body)


### PR DESCRIPTION
## Summary

Renames every REST handler span from `"handler.<TypeName>"` to `"rest.<TypeName>"`, per `write-go-service`'s rule that a handler span name is `"<protocol>.<identifier>"`.

15 files under `internal/handlers/` (`rest.claimsGet.go`, `rest.credentialsCreate.go`, `rest.tokenRefresh.go`, …). Pure string-literal change in the `otel.Tracer().Start(...)` call — no behavior change, no test touched (none asserted on span names). `rest.ping.go` / `rest.health.go` already used `"rest.…"`; service-authentication has no gRPC handlers.

`go build ./...` and `go vet ./...` clean. (`make lint-go` couldn't run locally — a stale `golangci-lint.sum` in the checkout, unrelated to this change; CI runs it normally.)

Context: tech debt flagged while writing the split-out `write-go-service` skill; the equivalent sweep for `service-template` is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
