### PR TITLE
fix(handlers): map fall-through error sentinels; report errors on service spans

### DIFF
--- a/internal/handlers/rest.credentialsResetPassword.go
+++ b/internal/handlers/rest.credentialsResetPassword.go
@@ -61,6 +61,7 @@ func (handler *CredentialsResetPassword) ServeHTTP(w http.ResponseWriter, r *htt
 			dao.ErrCredentialsUpdatePasswordNotFound: http.StatusForbidden,
 			dao.ErrShortCodeSelectNotFound:           http.StatusForbidden,
 			services.ErrShortCodeConsumeInvalid:      http.StatusForbidden,
+			services.ErrShortCodeConsumeExpired:      http.StatusForbidden,
 			services.ErrInvalidRequest:               http.StatusUnprocessableEntity,
 		}, err)
 

--- a/internal/handlers/rest.credentialsUpdateRole.go
+++ b/internal/handlers/rest.credentialsUpdateRole.go
@@ -64,7 +64,9 @@ func (handler *CredentialsUpdateRole) ServeHTTP(w http.ResponseWriter, r *http.R
 	})
 	if err != nil {
 		httpf.HandleError(ctx, handler.logger, w, span, httpf.ErrMap{
-			dao.ErrCredentialsUpdateRoleNotFound:               http.StatusNotFound,
+			dao.ErrCredentialsUpdateRoleNotFound: http.StatusNotFound,
+			// The target (or actor) credentials don't exist — surfaced by the select, not the update.
+			dao.ErrCredentialsSelectNotFound:                   http.StatusNotFound,
 			services.ErrCredentialsUpdateRoleToHigher:          http.StatusForbidden,
 			services.ErrCredentialsUpdateRoleDowngradeSuperior: http.StatusForbidden,
 			services.ErrCredentialsUpdateRoleSelfUpdate:        http.StatusForbidden,

--- a/internal/handlers/rest.credentialsUpdateRole_test.go
+++ b/internal/handlers/rest.credentialsUpdateRole_test.go
@@ -103,6 +103,29 @@ func TestCredentialsUpdateRole(t *testing.T) {
 			expectStatus: http.StatusNotFound,
 		},
 		{
+			name: "Error/TargetNotFound",
+
+			request: httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(`{
+				"userID": "00000000-0000-0000-0000-000000000002",
+				"role": "auth:admin"
+			}`)),
+			claims: &services.AccessTokenClaims{
+				UserID: lo.ToPtr(uuid.MustParse("00000000-0000-0000-0000-000000000001")),
+			},
+
+			serviceMock: &serviceMock{
+				req: &services.CredentialsUpdateRoleRequest{
+					Role:          config.RoleAdmin,
+					TargetUserID:  uuid.MustParse("00000000-0000-0000-0000-000000000002"),
+					CurrentUserID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+				},
+				// A missing target user is surfaced by the credentials select, not the update.
+				err: dao.ErrCredentialsSelectNotFound,
+			},
+
+			expectStatus: http.StatusNotFound,
+		},
+		{
 			name: "Error/RoleToHigher",
 
 			request: httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(`{

--- a/internal/handlers/rest.tokenRefresh.go
+++ b/internal/handlers/rest.tokenRefresh.go
@@ -9,6 +9,7 @@ import (
 	"github.com/a-novel-kit/golib/logging"
 	"github.com/a-novel-kit/golib/otel"
 
+	"github.com/a-novel/service-authentication/v2/internal/dao"
 	"github.com/a-novel/service-authentication/v2/internal/services"
 )
 
@@ -55,7 +56,9 @@ func (handler *TokenRefresh) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			services.ErrTokenRefreshInvalidRefreshToken: http.StatusForbidden,
 			services.ErrTokenRefreshMismatchClaims:      http.StatusForbidden,
 			services.ErrTokenRefreshMismatchSource:      http.StatusForbidden,
-			services.ErrInvalidRequest:                  http.StatusUnprocessableEntity,
+			// The credentials behind a still-valid refresh token were deleted — re-authenticate.
+			dao.ErrCredentialsSelectNotFound: http.StatusUnauthorized,
+			services.ErrInvalidRequest:       http.StatusUnprocessableEntity,
 		}, err)
 
 		return

--- a/internal/services/credentialsCreate.go
+++ b/internal/services/credentialsCreate.go
@@ -86,7 +86,7 @@ func (service *CredentialsCreate) Exec(ctx context.Context, request *Credentials
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, errors.Join(err, ErrInvalidRequest)
+		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
 	}
 
 	// Encrypt the password.

--- a/internal/services/credentialsCreateSuperAdmin.go
+++ b/internal/services/credentialsCreateSuperAdmin.go
@@ -64,7 +64,7 @@ func (service *CredentialsCreateSuperAdmin) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, errors.Join(err, ErrInvalidRequest)
+		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
 	}
 
 	encryptedPassword, err := lib.GenerateArgon2(request.Password, lib.Argon2ParamsDefault)

--- a/internal/services/credentialsList.go
+++ b/internal/services/credentialsList.go
@@ -41,7 +41,7 @@ func (service *CredentialsList) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, errors.Join(err, ErrInvalidRequest)
+		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
 	}
 
 	entities, err := service.repository.Exec(ctx, &dao.CredentialsListRequest{

--- a/internal/services/credentialsUpdateEmail.go
+++ b/internal/services/credentialsUpdateEmail.go
@@ -54,7 +54,7 @@ func (service *CredentialsUpdateEmail) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, errors.Join(err, ErrInvalidRequest)
+		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
 	}
 
 	var credentials *dao.Credentials

--- a/internal/services/credentialsUpdatePassword.go
+++ b/internal/services/credentialsUpdatePassword.go
@@ -66,7 +66,7 @@ func (service *CredentialsUpdatePassword) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, errors.Join(err, ErrInvalidRequest)
+		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
 	}
 
 	// Encrypt the new password.

--- a/internal/services/credentialsUpdateRole.go
+++ b/internal/services/credentialsUpdateRole.go
@@ -74,12 +74,12 @@ func (service *CredentialsUpdateRole) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, errors.Join(err, ErrInvalidRequest)
+		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
 	}
 
 	// No self-update allowed.
 	if request.CurrentUserID == request.TargetUserID {
-		return nil, ErrCredentialsUpdateRoleSelfUpdate
+		return nil, otel.ReportError(span, ErrCredentialsUpdateRoleSelfUpdate)
 	}
 
 	newTargetRoleImportance := config.PermissionsConfigDefault.Roles[request.Role].Priority
@@ -115,18 +115,18 @@ func (service *CredentialsUpdateRole) Exec(
 
 	// User can only upgrade users up to its own role.
 	if newTargetRoleImportance >= targetRoleIImportance && newTargetRoleImportance > currentRoleIImportance {
-		return nil, fmt.Errorf(
+		return nil, otel.ReportError(span, fmt.Errorf(
 			"%w: upgrade from %s to %s",
 			ErrCredentialsUpdateRoleToHigher, currentCredentials.Role, request.Role,
-		)
+		))
 	}
 
 	// User can only downgrade users from a lower role.
 	if newTargetRoleImportance <= targetRoleIImportance && targetRoleIImportance >= currentRoleIImportance {
-		return nil, fmt.Errorf(
+		return nil, otel.ReportError(span, fmt.Errorf(
 			"%w: downgrade from %s to %s",
 			ErrCredentialsUpdateRoleDowngradeSuperior, currentCredentials.Role, request.Role,
-		)
+		))
 	}
 
 	// If new role is equal to the current role, return the target credentials (noop).

--- a/internal/services/shortCodeConsume.go
+++ b/internal/services/shortCodeConsume.go
@@ -62,7 +62,7 @@ func (service *ShortCodeConsume) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, errors.Join(err, ErrInvalidRequest)
+		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
 	}
 
 	entity, err := service.repositorySelect.Exec(ctx, &dao.ShortCodeSelectRequest{
@@ -84,23 +84,20 @@ func (service *ShortCodeConsume) Exec(
 
 	// Explicit expiration check as defense-in-depth (SQL already filters expired codes).
 	if entity.ExpiresAt.Before(time.Now()) {
-		return nil, ErrShortCodeConsumeExpired
+		return nil, otel.ReportError(span, ErrShortCodeConsumeExpired)
 	}
 
 	// Compare the encrypted code with the plain code of the request.
 	err = lib.CompareArgon2(request.Code, entity.Code)
 	if err != nil {
-		joined := errors.Join(
+		// lib.ErrInvalidPassword is the expected outcome (mistyped / stale code, handler → 4xx);
+		// the other CompareArgon2 errors (lib.ErrInvalidHash, lib.ErrIncompatibleVersion) mean
+		// the stored short-code hash is malformed. Both are reported on the span and surfaced to
+		// the caller as ErrShortCodeConsumeInvalid.
+		return nil, otel.ReportError(span, errors.Join(
 			fmt.Errorf("compare short code: %w", err),
 			ErrShortCodeConsumeInvalid,
-		)
-		if errors.Is(err, lib.ErrInvalidPassword) {
-			// Wrong code is the expected user-facing outcome (mistyped code, stale request).
-			return nil, joined
-		}
-		// Other CompareArgon2 errors (lib.ErrInvalidHash, lib.ErrIncompatibleVersion) mean
-		// the stored short-code hash itself is malformed — operational failure worth reporting.
-		return nil, otel.ReportError(span, joined)
+		))
 	}
 
 	// Delete the short code from the database. It has been consumed.

--- a/internal/services/shortCodeCreate.go
+++ b/internal/services/shortCodeCreate.go
@@ -55,7 +55,7 @@ func (service *ShortCodeCreate) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, errors.Join(err, ErrInvalidRequest)
+		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
 	}
 
 	// Generate a new random code.

--- a/internal/services/shortCodeCreateEmailUpdate.go
+++ b/internal/services/shortCodeCreateEmailUpdate.go
@@ -79,7 +79,7 @@ func (service *ShortCodeCreateEmailUpdate) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, errors.Join(err, ErrInvalidRequest)
+		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
 	}
 
 	_, err = service.selectRepository.Exec(ctx, &dao.CredentialsSelectByEmailRequest{

--- a/internal/services/shortCodeCreatePasswordReset.go
+++ b/internal/services/shortCodeCreatePasswordReset.go
@@ -74,7 +74,7 @@ func (service *ShortCodeCreatePasswordReset) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, errors.Join(err, ErrInvalidRequest)
+		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
 	}
 
 	credentials, err := service.selectRepository.Exec(ctx, &dao.CredentialsSelectByEmailRequest{

--- a/internal/services/shortCodeCreateRegister.go
+++ b/internal/services/shortCodeCreateRegister.go
@@ -76,7 +76,7 @@ func (service *ShortCodeCreateRegister) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, errors.Join(err, ErrInvalidRequest)
+		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
 	}
 
 	_, err = service.selectRepository.Exec(ctx, &dao.CredentialsSelectByEmailRequest{

--- a/internal/services/tokenCreate.go
+++ b/internal/services/tokenCreate.go
@@ -74,7 +74,7 @@ func (service *TokenCreate) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, errors.Join(err, ErrInvalidRequest)
+		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
 	}
 
 	// Retrieve credentials.
@@ -100,13 +100,9 @@ func (service *TokenCreate) Exec(
 	// Validate password.
 	err = lib.CompareArgon2(request.Password, credentials.Password)
 	if err != nil {
-		if errors.Is(err, lib.ErrInvalidPassword) {
-			// Wrong password is the expected user-facing outcome — don't mark the span as
-			// failed. The handler maps lib.ErrInvalidPassword to 401 downstream.
-			return nil, fmt.Errorf("compare password: %w", err)
-		}
-		// Other CompareArgon2 errors (lib.ErrInvalidHash, lib.ErrIncompatibleVersion) mean
-		// the stored hash itself is malformed — operational failure worth reporting.
+		// lib.ErrInvalidPassword is the expected outcome the handler maps to 401; the other
+		// CompareArgon2 errors (lib.ErrInvalidHash, lib.ErrIncompatibleVersion) mean the stored
+		// hash is malformed. Both are reported on the span — it shows what the request hit.
 		return nil, otel.ReportError(span, fmt.Errorf("compare password: %w", err))
 	}
 

--- a/internal/services/tokenRefresh.go
+++ b/internal/services/tokenRefresh.go
@@ -93,7 +93,7 @@ func (service *TokenRefresh) Exec(
 
 	err := validate.Struct(request)
 	if err != nil {
-		return nil, errors.Join(err, ErrInvalidRequest)
+		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
 	}
 
 	// Step 1: Verify the access token signature.
@@ -109,7 +109,7 @@ func (service *TokenRefresh) Exec(
 	)
 	if err != nil {
 		if errors.Is(err, jws.ErrInvalidSignature) || errors.Is(err, jwp.ErrInvalidClaims) {
-			return nil, errors.Join(err, ErrTokenRefreshInvalidAccessToken)
+			return nil, otel.ReportError(span, errors.Join(err, ErrTokenRefreshInvalidAccessToken))
 		}
 
 		return nil, otel.ReportError(span, err)
@@ -126,7 +126,7 @@ func (service *TokenRefresh) Exec(
 	)
 	if err != nil {
 		if errors.Is(err, jws.ErrInvalidSignature) || errors.Is(err, jwp.ErrInvalidClaims) {
-			return nil, errors.Join(err, ErrTokenRefreshInvalidRefreshToken)
+			return nil, otel.ReportError(span, errors.Join(err, ErrTokenRefreshInvalidRefreshToken))
 		}
 
 		return nil, otel.ReportError(span, err)
@@ -140,7 +140,7 @@ func (service *TokenRefresh) Exec(
 	// Step 3: Verify that both tokens belong to the same user.
 	// This prevents an attacker from using a stolen refresh token with a different user's access token.
 	if lo.FromPtr(accessTokenClaims.UserID) != refreshTokenClaims.UserID {
-		return nil, ErrTokenRefreshMismatchClaims
+		return nil, otel.ReportError(span, ErrTokenRefreshMismatchClaims)
 	}
 
 	span.SetAttributes(
@@ -154,7 +154,7 @@ func (service *TokenRefresh) Exec(
 	//   - An access token can only be refreshed using its original refresh token
 	//   - Revoking a refresh token effectively revokes all access tokens derived from it
 	if accessTokenClaims.RefreshTokenID != refreshTokenClaims.Jti {
-		return nil, ErrTokenRefreshMismatchSource
+		return nil, otel.ReportError(span, ErrTokenRefreshMismatchSource)
 	}
 
 	// Retrieve updated credentials.


### PR DESCRIPTION
## Summary

Two related cleanups on how errors surface in `service-authentication`, surfaced as follow-ups during the skills work.

### 1. Error sentinels that fell through to 500 (`fix(handlers)` + `test(handlers)`)

Three handlers returned a generic 500 on outcomes that have a correct 4xx:

- **`rest.tokenRefresh.go`** — a refresh whose credentials were deleted surfaces `dao.ErrCredentialsSelectNotFound`; now mapped to **401** (re-authenticate). Defensive — moot today since there's no delete-credentials endpoint.
- **`rest.credentialsResetPassword.go`** — `services.ErrShortCodeConsumeExpired` was unmapped; now **403**, alongside the existing `ErrShortCodeConsumeInvalid` mapping. (Only fires on DB/service clock skew — the SELECT already filters expired rows.)
- **`rest.credentialsUpdateRole.go`** — a missing **target** user surfaces `dao.ErrCredentialsSelectNotFound` (from the credentials *select*; the *update* never runs), which was unmapped → 500. Now **404**. Covered by a new `Error/TargetNotFound` test case (the deleted-user-refresh and clock-skew-expired cases are edge/moot and left untested).

### 2. Every span'd layer reports its errors (`refactor(services)`)

Per the corrected `feedback_sentinels_no_span_report` rule (every layer with a span records every error it sees — raised, propagated, or surfaced — and `httpf.HandleError` already does this for handlers), the bare sentinel returns in `internal/services/` now go through `otel.ReportError(span, …)`:

- `validate.Struct` failure in every `Exec` → `otel.ReportError(span, errors.Join(err, ErrInvalidRequest))`.
- `tokenRefresh`: the invalid-access/refresh-token branches and the `Mismatch{Claims,Source}` returns.
- `tokenCreate` / `shortCodeConsume`: the `lib.ErrInvalidPassword` (wrong password / wrong code) branches — collapsed with the malformed-stored-hash branch (both now report identically) and the comments updated (the old "don't mark the span as failed" line was wrong).
- `shortCodeConsume`: the explicit-expiry `ErrShortCodeConsumeExpired` return.
- `credentialsUpdateRole`: the `SelfUpdate` / `ToHigher` / `DowngradeSuperior` returns.

**No behavior change** — `otel.ReportError` returns `err` unchanged, so `errors.Is` chains and the handler error maps are untouched. This brings `service-authentication`'s services in line with `service-template`'s and with the now-codified rule.

`go build` / `go vet` clean; the mock-based service tests and the `handlers` tests pass locally (the DB-backed `TestCredentialsCreateSuperAdmin` etc. need Postgres — CI runs them). `make lint-go` couldn't run locally (stale `golangci-lint.sum` in the checkout, unrelated) — CI will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
