### PR TITLE
test(dao): isolate DAO tests per-database, run them in parallel

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -150,7 +150,3 @@ linters:
           - goconst
           - gocritic
           - err113
-      - path: dao/(.+)_test.go
-        linters:
-          - paralleltest
-          - tparallel

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 tool github.com/vektra/mockery/v3
 
 require (
-	github.com/a-novel-kit/golib v0.21.0
+	github.com/a-novel-kit/golib v0.21.1-0.20260515231839-997ef53fe122
 	github.com/a-novel-kit/jwt v1.1.59
 	github.com/a-novel/service-json-keys/v2 v2.3.0
 	github.com/go-chi/chi/v5 v5.2.5

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ tool github.com/vektra/mockery/v3
 require (
 	github.com/a-novel-kit/golib v0.22.0
 	github.com/a-novel-kit/jwt v1.1.59
-	github.com/a-novel/service-json-keys/v2 v2.3.0
+	github.com/a-novel/service-json-keys/v2 v2.3.1-0.20260515223604-9b9e50a9ecb7
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/cors v1.2.2
 	github.com/go-playground/validator/v10 v10.30.2

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 tool github.com/vektra/mockery/v3
 
 require (
-	github.com/a-novel-kit/golib v0.21.1-0.20260515231839-997ef53fe122
+	github.com/a-novel-kit/golib v0.22.0
 	github.com/a-novel-kit/jwt v1.1.59
 	github.com/a-novel/service-json-keys/v2 v2.3.0
 	github.com/go-chi/chi/v5 v5.2.5

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.56.0/go.mod h1:6ZZMQhZKDvUvkJw2rc+oDP90tMMzuU/J+5HG1ZmPOmE=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.56.0 h1:uYhkFf0DtbxOa5f2o2BqwMNWzAAhzHn67jukamPtWIA=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.56.0/go.mod h1:sKE2BdlsRRPL7ONGioxJnjUhEA1NbF484vFq8LX6znI=
-github.com/a-novel-kit/golib v0.21.0 h1:YeYw75+s7iRYBtV11P9FaaepIevISSwXYf9llzYFV/w=
-github.com/a-novel-kit/golib v0.21.0/go.mod h1:kpQ/AzbFg7DrAqFeXObxCI8bCd5O/pG8y4t8tSdO0Yo=
+github.com/a-novel-kit/golib v0.21.1-0.20260515231839-997ef53fe122 h1:uE2Fo5y8qFNdtcyw7KdnKOzkeN2jbKHHhhCfvhEPEpA=
+github.com/a-novel-kit/golib v0.21.1-0.20260515231839-997ef53fe122/go.mod h1:kpQ/AzbFg7DrAqFeXObxCI8bCd5O/pG8y4t8tSdO0Yo=
 github.com/a-novel-kit/jwt v1.1.59 h1:qsaemGgPeISLH49s2PKM2U1zp852Kkr+a0tl9er+ryM=
 github.com/a-novel-kit/jwt v1.1.59/go.mod h1:C8vBO63pmAh1afGl7B+0KExZ1X0d/Dwn/erB8I6Vhw8=
 github.com/a-novel/service-json-keys/v2 v2.3.0 h1:mni8LnJttkfh1leU9ILasAS4pO6ElcS2AldrB23HqSE=

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/a-novel-kit/golib v0.22.0 h1:vUIC6eal/lzmiyM5Cb4jpc0EhLWyNbhb6CAEgktL
 github.com/a-novel-kit/golib v0.22.0/go.mod h1:kpQ/AzbFg7DrAqFeXObxCI8bCd5O/pG8y4t8tSdO0Yo=
 github.com/a-novel-kit/jwt v1.1.59 h1:qsaemGgPeISLH49s2PKM2U1zp852Kkr+a0tl9er+ryM=
 github.com/a-novel-kit/jwt v1.1.59/go.mod h1:C8vBO63pmAh1afGl7B+0KExZ1X0d/Dwn/erB8I6Vhw8=
-github.com/a-novel/service-json-keys/v2 v2.3.0 h1:mni8LnJttkfh1leU9ILasAS4pO6ElcS2AldrB23HqSE=
-github.com/a-novel/service-json-keys/v2 v2.3.0/go.mod h1:fVddi6Rarhq2dR/rqwmfXckScv+FgiksQcIlSjGmdVU=
+github.com/a-novel/service-json-keys/v2 v2.3.1-0.20260515223604-9b9e50a9ecb7 h1:x9rd7azch9vY84lTy6JLYrgOEZ0smqF5OqqdGReMutw=
+github.com/a-novel/service-json-keys/v2 v2.3.1-0.20260515223604-9b9e50a9ecb7/go.mod h1:4Pz9bHbffZEos6qRcoFAulTU2j3SkX61pSBr8aV99qc=
 github.com/brunoga/deep v1.3.1 h1:bSrL6FhAZa6JlVv4vsi7Hg8SLwroDb1kgDERRVipBCo=
 github.com/brunoga/deep v1.3.1/go.mod h1:GDV6dnXqn80ezsLSZ5Wlv1PdKAWAO4L5PnKYtv2dgaI=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.56.0/go.mod h1:6ZZMQhZKDvUvkJw2rc+oDP90tMMzuU/J+5HG1ZmPOmE=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.56.0 h1:uYhkFf0DtbxOa5f2o2BqwMNWzAAhzHn67jukamPtWIA=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.56.0/go.mod h1:sKE2BdlsRRPL7ONGioxJnjUhEA1NbF484vFq8LX6znI=
-github.com/a-novel-kit/golib v0.21.1-0.20260515231839-997ef53fe122 h1:uE2Fo5y8qFNdtcyw7KdnKOzkeN2jbKHHhhCfvhEPEpA=
-github.com/a-novel-kit/golib v0.21.1-0.20260515231839-997ef53fe122/go.mod h1:kpQ/AzbFg7DrAqFeXObxCI8bCd5O/pG8y4t8tSdO0Yo=
+github.com/a-novel-kit/golib v0.22.0 h1:vUIC6eal/lzmiyM5Cb4jpc0EhLWyNbhb6CAEgktLrSA=
+github.com/a-novel-kit/golib v0.22.0/go.mod h1:kpQ/AzbFg7DrAqFeXObxCI8bCd5O/pG8y4t8tSdO0Yo=
 github.com/a-novel-kit/jwt v1.1.59 h1:qsaemGgPeISLH49s2PKM2U1zp852Kkr+a0tl9er+ryM=
 github.com/a-novel-kit/jwt v1.1.59/go.mod h1:C8vBO63pmAh1afGl7B+0KExZ1X0d/Dwn/erB8I6Vhw8=
 github.com/a-novel/service-json-keys/v2 v2.3.0 h1:mni8LnJttkfh1leU9ILasAS4pO6ElcS2AldrB23HqSE=

--- a/internal/dao/pg.credentialsExist_test.go
+++ b/internal/dao/pg.credentialsExist_test.go
@@ -12,9 +12,12 @@ import (
 
 	"github.com/a-novel/service-authentication/v2/internal/config/configtest"
 	"github.com/a-novel/service-authentication/v2/internal/dao"
+	"github.com/a-novel/service-authentication/v2/internal/models/migrations"
 )
 
 func TestCredentialsExist(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name string
 
@@ -60,7 +63,9 @@ func TestCredentialsExist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			postgres.RunTransactionalTest(t, configtest.PostgresPreset, func(ctx context.Context, t *testing.T) {
+			t.Parallel()
+
+			postgres.RunDBTest(t, configtest.PostgresPreset, migrations.Migrations, func(ctx context.Context, t *testing.T) {
 				t.Helper()
 
 				db, err := postgres.GetContext(ctx)

--- a/internal/dao/pg.credentialsInsert_test.go
+++ b/internal/dao/pg.credentialsInsert_test.go
@@ -12,9 +12,12 @@ import (
 
 	"github.com/a-novel/service-authentication/v2/internal/config/configtest"
 	"github.com/a-novel/service-authentication/v2/internal/dao"
+	"github.com/a-novel/service-authentication/v2/internal/models/migrations"
 )
 
 func TestCredentialsInsert(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name string
 
@@ -93,7 +96,9 @@ func TestCredentialsInsert(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			postgres.RunTransactionalTest(t, configtest.PostgresPreset, func(ctx context.Context, t *testing.T) {
+			t.Parallel()
+
+			postgres.RunDBTest(t, configtest.PostgresPreset, migrations.Migrations, func(ctx context.Context, t *testing.T) {
 				t.Helper()
 
 				db, err := postgres.GetContext(ctx)

--- a/internal/dao/pg.credentialsList_test.go
+++ b/internal/dao/pg.credentialsList_test.go
@@ -12,9 +12,12 @@ import (
 
 	"github.com/a-novel/service-authentication/v2/internal/config/configtest"
 	"github.com/a-novel/service-authentication/v2/internal/dao"
+	"github.com/a-novel/service-authentication/v2/internal/models/migrations"
 )
 
 func TestCredentialsList(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name string
 
@@ -228,7 +231,9 @@ func TestCredentialsList(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			postgres.RunTransactionalTest(t, configtest.PostgresPreset, func(ctx context.Context, t *testing.T) {
+			t.Parallel()
+
+			postgres.RunDBTest(t, configtest.PostgresPreset, migrations.Migrations, func(ctx context.Context, t *testing.T) {
 				t.Helper()
 
 				db, err := postgres.GetContext(ctx)

--- a/internal/dao/pg.credentialsSelectByEmail_test.go
+++ b/internal/dao/pg.credentialsSelectByEmail_test.go
@@ -12,9 +12,12 @@ import (
 
 	"github.com/a-novel/service-authentication/v2/internal/config/configtest"
 	"github.com/a-novel/service-authentication/v2/internal/dao"
+	"github.com/a-novel/service-authentication/v2/internal/models/migrations"
 )
 
 func TestCredentialsSelectByEmail(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name string
 
@@ -67,7 +70,9 @@ func TestCredentialsSelectByEmail(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			postgres.RunTransactionalTest(t, configtest.PostgresPreset, func(ctx context.Context, t *testing.T) {
+			t.Parallel()
+
+			postgres.RunDBTest(t, configtest.PostgresPreset, migrations.Migrations, func(ctx context.Context, t *testing.T) {
 				t.Helper()
 
 				db, err := postgres.GetContext(ctx)

--- a/internal/dao/pg.credentialsSelect_test.go
+++ b/internal/dao/pg.credentialsSelect_test.go
@@ -12,9 +12,12 @@ import (
 
 	"github.com/a-novel/service-authentication/v2/internal/config/configtest"
 	"github.com/a-novel/service-authentication/v2/internal/dao"
+	"github.com/a-novel/service-authentication/v2/internal/models/migrations"
 )
 
 func TestCredentialsSelect(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name string
 
@@ -67,7 +70,9 @@ func TestCredentialsSelect(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			postgres.RunTransactionalTest(t, configtest.PostgresPreset, func(ctx context.Context, t *testing.T) {
+			t.Parallel()
+
+			postgres.RunDBTest(t, configtest.PostgresPreset, migrations.Migrations, func(ctx context.Context, t *testing.T) {
 				t.Helper()
 
 				db, err := postgres.GetContext(ctx)

--- a/internal/dao/pg.credentialsUpdateEmail_test.go
+++ b/internal/dao/pg.credentialsUpdateEmail_test.go
@@ -12,9 +12,12 @@ import (
 
 	"github.com/a-novel/service-authentication/v2/internal/config/configtest"
 	"github.com/a-novel/service-authentication/v2/internal/dao"
+	"github.com/a-novel/service-authentication/v2/internal/models/migrations"
 )
 
 func TestCredentialsUpdateEmail(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name string
 
@@ -101,7 +104,9 @@ func TestCredentialsUpdateEmail(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			postgres.RunTransactionalTest(t, configtest.PostgresPreset, func(ctx context.Context, t *testing.T) {
+			t.Parallel()
+
+			postgres.RunDBTest(t, configtest.PostgresPreset, migrations.Migrations, func(ctx context.Context, t *testing.T) {
 				t.Helper()
 
 				db, err := postgres.GetContext(ctx)

--- a/internal/dao/pg.credentialsUpdatePassword_test.go
+++ b/internal/dao/pg.credentialsUpdatePassword_test.go
@@ -12,9 +12,12 @@ import (
 
 	"github.com/a-novel/service-authentication/v2/internal/config/configtest"
 	"github.com/a-novel/service-authentication/v2/internal/dao"
+	"github.com/a-novel/service-authentication/v2/internal/models/migrations"
 )
 
 func TestCredentialsUpdatePassword(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name string
 
@@ -126,7 +129,9 @@ func TestCredentialsUpdatePassword(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			postgres.RunTransactionalTest(t, configtest.PostgresPreset, func(ctx context.Context, t *testing.T) {
+			t.Parallel()
+
+			postgres.RunDBTest(t, configtest.PostgresPreset, migrations.Migrations, func(ctx context.Context, t *testing.T) {
 				t.Helper()
 
 				db, err := postgres.GetContext(ctx)

--- a/internal/dao/pg.credentialsUpdateRole_test.go
+++ b/internal/dao/pg.credentialsUpdateRole_test.go
@@ -12,9 +12,12 @@ import (
 
 	"github.com/a-novel/service-authentication/v2/internal/config/configtest"
 	"github.com/a-novel/service-authentication/v2/internal/dao"
+	"github.com/a-novel/service-authentication/v2/internal/models/migrations"
 )
 
 func TestCredentialsUpdateRole(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name string
 
@@ -71,7 +74,9 @@ func TestCredentialsUpdateRole(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			postgres.RunTransactionalTest(t, configtest.PostgresPreset, func(ctx context.Context, t *testing.T) {
+			t.Parallel()
+
+			postgres.RunDBTest(t, configtest.PostgresPreset, migrations.Migrations, func(ctx context.Context, t *testing.T) {
 				t.Helper()
 
 				db, err := postgres.GetContext(ctx)

--- a/internal/dao/pg.shortCodeDelete_test.go
+++ b/internal/dao/pg.shortCodeDelete_test.go
@@ -13,9 +13,12 @@ import (
 
 	"github.com/a-novel/service-authentication/v2/internal/config/configtest"
 	"github.com/a-novel/service-authentication/v2/internal/dao"
+	"github.com/a-novel/service-authentication/v2/internal/models/migrations"
 )
 
 func TestShortCodeDelete(t *testing.T) {
+	t.Parallel()
+
 	hourAgo := time.Now().Add(-time.Hour).UTC().Round(time.Second)
 	now := time.Now().UTC().Round(time.Second)
 	hourLater := time.Now().Add(time.Hour).UTC().Round(time.Second)
@@ -150,7 +153,9 @@ func TestShortCodeDelete(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			postgres.RunTransactionalTest(t, configtest.PostgresPreset, func(ctx context.Context, t *testing.T) {
+			t.Parallel()
+
+			postgres.RunDBTest(t, configtest.PostgresPreset, migrations.Migrations, func(ctx context.Context, t *testing.T) {
 				t.Helper()
 
 				db, err := postgres.GetContext(ctx)

--- a/internal/dao/pg.shortCodeInsert_test.go
+++ b/internal/dao/pg.shortCodeInsert_test.go
@@ -13,9 +13,12 @@ import (
 
 	"github.com/a-novel/service-authentication/v2/internal/config/configtest"
 	"github.com/a-novel/service-authentication/v2/internal/dao"
+	"github.com/a-novel/service-authentication/v2/internal/models/migrations"
 )
 
 func TestShortCodeInsert(t *testing.T) {
+	t.Parallel()
+
 	now := time.Now().UTC().Round(time.Second)
 	hourAgo := time.Now().Add(-time.Hour).UTC().Round(time.Second)
 	hourLater := time.Now().Add(time.Hour).UTC().Round(time.Second)
@@ -285,7 +288,9 @@ func TestShortCodeInsert(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			postgres.RunTransactionalTest(t, configtest.PostgresPreset, func(ctx context.Context, t *testing.T) {
+			t.Parallel()
+
+			postgres.RunDBTest(t, configtest.PostgresPreset, migrations.Migrations, func(ctx context.Context, t *testing.T) {
 				t.Helper()
 
 				db, err := postgres.GetContext(ctx)

--- a/internal/dao/pg.shortCodeSelect_test.go
+++ b/internal/dao/pg.shortCodeSelect_test.go
@@ -13,9 +13,12 @@ import (
 
 	"github.com/a-novel/service-authentication/v2/internal/config/configtest"
 	"github.com/a-novel/service-authentication/v2/internal/dao"
+	"github.com/a-novel/service-authentication/v2/internal/models/migrations"
 )
 
 func TestShortCodeSelect(t *testing.T) {
+	t.Parallel()
+
 	hourAgo := time.Now().Add(-time.Hour).UTC().Round(time.Second)
 	hourLater := time.Now().Add(time.Hour).UTC().Round(time.Second)
 
@@ -121,7 +124,9 @@ func TestShortCodeSelect(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			postgres.RunTransactionalTest(t, configtest.PostgresPreset, func(ctx context.Context, t *testing.T) {
+			t.Parallel()
+
+			postgres.RunDBTest(t, configtest.PostgresPreset, migrations.Migrations, func(ctx context.Context, t *testing.T) {
 				t.Helper()
 
 				db, err := postgres.GetContext(ctx)


### PR DESCRIPTION
## Summary

- Switches every `internal/dao/*_test.go` from `postgres.RunTransactionalTest` to the new `postgres.RunDBTest` (a-novel-kit/golib#269), which clones a migrated template database per test instead of sharing one schema under a rolled-back transaction.
- Adds `t.Parallel()` to every outer DAO test **and** every sub-test, and removes the now-obsolete `dao/(.+)_test.go` `paralleltest`/`tparallel` golangci exclusion so parallelism is lint-enforced going forward.

## Why

`RunTransactionalTest` isolates by rolling back a transaction on the shared `public` schema — correct only when DAO tests run serially. Under `t.Parallel()`, concurrent transactions insert the same hard-coded fixture keys into the same tables and Postgres deadlocks (SQLSTATE 40P01). That is why DAO tests were excluded from the parallel linters and ran serially. `RunDBTest` gives each test a physically isolated database, removing the constraint.

## Layers changed

- **DAO (tests only)**: 11 `*_test.go` files migrated to `RunDBTest` + `t.Parallel()`. No production code changed.
- **Config**: `.golangci.yaml` — dropped the `dao/*_test.go` `paralleltest`/`tparallel` exclusion.
- **deps**: in-flight pseudo-version pin to golib#269 (see merge order).

## Validation

Full `internal/dao` suite run against the test Postgres: **green in ~12s** with every outer test and sub-test `t.Parallel()`, zero deadlocks. `golangci-lint` on `./internal/dao/...` clean (parallel linters now enforced).

## Merge order (cross-repo — dependency first)

1. **a-novel-kit/golib#269** (`RunDBTest`) → merge → release `vX.Y.Z`
2. Re-pin here: `go get github.com/a-novel-kit/golib@vX.Y.Z && go mod tidy`, replacing the pseudo-version commit (`chore(deps): bump golib to vX.Y.Z`) → CI green
3. Merge this PR

**Do not merge on the pseudo-version pin.** A red "released versions only" check is expected until step 2.

## Known caveat (out of scope)

golib `master` already contains the v1.0 breaking removal of deprecated logging symbols (golib#267), which the pinned `service-json-keys@v2.3.0` has not migrated to. Until that org-wide golib-v1.0 ↔ json-keys migration lands, a full `make test-unit` build is red for that unrelated transitive reason; the DAO change itself is validated above (the `internal/dao` package does not import the json-keys client).

## Test plan

- [x] `internal/dao` suite green under full parallelism (local, real Postgres)
- [x] `golangci-lint ./internal/dao/...` clean
- [ ] Full `make test-unit` — blocked on the golib-v1.0 / json-keys migration noted above
- [ ] Re-pin golib to released tag before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
