### PR TITLE
docs(readme): drop the codecov graph token from badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/a-novel/service-authentication/main.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/a-novel/service-authentication)](https://goreportcard.com/report/github.com/a-novel/service-authentication)
-[![codecov](https://codecov.io/gh/a-novel/service-authentication/graph/badge.svg?token=cnSwTJ2q4n)](https://codecov.io/gh/a-novel/service-authentication)
+[![codecov](https://codecov.io/gh/a-novel/service-authentication/graph/badge.svg)](https://codecov.io/gh/a-novel/service-authentication)
 
-![Coverage graph](https://codecov.io/gh/a-novel/service-authentication/graphs/sunburst.svg?token=cnSwTJ2q4n)
+![Coverage graph](https://codecov.io/gh/a-novel/service-authentication/graphs/sunburst.svg)
 
 ## Usage
 


### PR DESCRIPTION
Public-repo Codecov badges render without a token, so the graph token in the badge + sunburst URLs is unnecessary. Stripping it for cleaner, tokenless badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)