### PR TITLE
chore(deps): bump a-novel-kit/workflows to v1.3.1

### DIFF
--- a/.github/workflows/auto-approve-dependabot.yaml
+++ b/.github/workflows/auto-approve-dependabot.yaml
@@ -14,11 +14,11 @@ jobs:
     if: ${{ github.event.pull_request.user.login == vars.DEPENDENCY_BOT_LOGIN || github.event.pull_request.user.login == vars.DEPENDABOT_SECURITY_LOGIN }}
     steps:
       - uses: actions/checkout@v7
-      - uses: a-novel-kit/workflows/generic-actions/approve-bot@v1.3.0
+      - uses: a-novel-kit/workflows/generic-actions/approve-bot@v1.3.1
         with:
           pull_request: ${{ github.event.pull_request.html_url }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: a-novel-kit/workflows/generic-actions/auto-merge-bot@v1.3.0
+      - uses: a-novel-kit/workflows/generic-actions/auto-merge-bot@v1.3.1
         # Renovate already activates auto-merge by itself.
         if: ${{ github.event.pull_request.user.login == vars.DEPENDABOT_SECURITY_LOGIN }}
         with:

--- a/.github/workflows/auto-assign-author.yaml
+++ b/.github/workflows/auto-assign-author.yaml
@@ -10,6 +10,6 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/assign-bot@v1.3.0
+      - uses: a-novel-kit/workflows/generic-actions/assign-bot@v1.3.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: go generate
         shell: bash
         run: go generate ./...
-      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.3.0
+      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.3.1
         with:
           fail_message: go generate definitions are not up-to-date, please run 'go generate ./...' and commit the changes
 
@@ -30,7 +30,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/pull-bot@v1.3.0
+      - uses: a-novel-kit/workflows/generic-actions/pull-bot@v1.3.1
         id: app_token
         with:
           client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}
@@ -53,7 +53,7 @@ jobs:
       - name: pnpm
         shell: bash
         run: pnpm generate
-      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.3.0
+      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.3.1
         with:
           fail_message: pnpm definitions are not up-to-date, please run 'pnpm generate' and commit the changes
 
@@ -63,7 +63,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.3.0
+      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.3.1
 
   lint-node:
     runs-on: ubuntu-latest
@@ -71,7 +71,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.3.0
+      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.3.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -107,7 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/go-actions/test-go@v1.3.0
+      - uses: a-novel-kit/workflows/go-actions/test-go@v1.3.1
         id: test
         with:
           filter_extra_patterns: " | grep -v /cmd"
@@ -201,7 +201,7 @@ jobs:
       SUPER_ADMIN_PASSWORD: admin
       MAIL_HOST: http://0.0.0.0:8025
     steps:
-      - uses: a-novel-kit/workflows/node-actions/test-node@v1.3.0
+      - uses: a-novel-kit/workflows/node-actions/test-node@v1.3.1
         id: test
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -226,7 +226,7 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.3.0
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.3.1
         id: build
         with:
           file: builds/database.Dockerfile
@@ -266,7 +266,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.3.0
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.3.1
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -304,7 +304,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.3.0
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.3.1
         with:
           file: builds/init.Dockerfile
           image_name: ${{ github.repository }}/jobs/init
@@ -366,7 +366,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.3.0
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.3.1
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -431,7 +431,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.3.0
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.3.1
         id: build
         with:
           file: builds/standalone.rest.Dockerfile
@@ -450,7 +450,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/build-node@v1.3.0
+      - uses: a-novel-kit/workflows/node-actions/build-node@v1.3.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -464,7 +464,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/go-actions/go-report-card@v1.3.0
+      - uses: a-novel-kit/workflows/go-actions/go-report-card@v1.3.1
         if: github.ref == 'refs/heads/master' && success()
 
   report-codecov:
@@ -473,7 +473,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.3.0
+      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.3.1
         with:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
           coverage_files: coverage.txt,coverage/*

--- a/.github/workflows/node-audit.yaml
+++ b/.github/workflows/node-audit.yaml
@@ -11,7 +11,7 @@ jobs:
       contents: write
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/audit@v1.3.0
+      - uses: a-novel-kit/workflows/node-actions/audit@v1.3.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
       tag: ${{ steps.core.outputs.tag }}
     steps:
       - id: core
-        uses: a-novel-kit/workflows/publish-actions/release-core@v1.3.0
+        uses: a-novel-kit/workflows/publish-actions/release-core@v1.3.1
         with:
           release_type: ${{ inputs.release_type }}
           dry_run: ${{ inputs.dry_run }}
@@ -71,7 +71,7 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.3.0
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.3.1
         with:
           file: builds/database.Dockerfile
           image_name: ${{ github.repository }}/database
@@ -112,7 +112,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.3.0
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.3.1
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -152,7 +152,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.3.0
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.3.1
         with:
           file: builds/init.Dockerfile
           image_name: ${{ github.repository }}/jobs/init
@@ -216,7 +216,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.3.0
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.3.1
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -281,7 +281,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.3.0
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.3.1
         with:
           file: builds/standalone.rest.Dockerfile
           image_name: ${{ github.repository }}/standalone-rest
@@ -303,7 +303,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: a-novel-kit/workflows/publish-actions/npm@v1.3.0
+      - uses: a-novel-kit/workflows/publish-actions/npm@v1.3.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}
@@ -325,7 +325,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.3.0
+      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.3.1
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
       security-events: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/renovate@v1.3.0
+      - uses: a-novel-kit/workflows/generic-actions/renovate@v1.3.1
         with:
           allowed_commands: |
             [


### PR DESCRIPTION
Bumps all `a-novel-kit/workflows@v1.3.0` → `@v1.3.1`, which carries the release-core `prepublish:doc` fix (#202): the dispatched release now stamps docs without pnpm's pre-run install (which 401'd on private `@a-novel-kit` deps and tripped the supply-chain check). Unblocks this service's dispatched release.

After merge, dispatch **release ▸ patch**.

Part of a-novel-kit/.github#36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)