### PR TITLE
docs: refocus comments on rationale and refine project docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Identity and session manager for the A-Novel platform: it owns user credentials,
 
 ## What it does
 
-Authentication owns **user identities** — email/password credentials, hashed with Argon2id — and the **token lifecycle**. Clients trade credentials (or nothing, for an anonymous session) for a short-lived access token and a long-lived refresh token, then refresh the pair without re-authenticating. Every account carries a role, and each role maps to a set of permissions that downstream services enforce per route.
+Authentication owns **user identities** — email/password credentials, hashed with Argon2id — and the **token lifecycle**. Clients trade credentials for a short-lived access token and a long-lived refresh token, then refresh the pair without re-authenticating; callers with no account get an anonymous, access-only token that cannot be refreshed. Every account carries a role, and each role maps to a set of permissions that downstream services enforce per route.
 
 Identity changes — registration, email change, password reset — are gated by single-use **short codes** emailed to the user, so a stolen session token alone can't take over an account.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Identity and session manager for the A-Novel platform: it owns user credentials,
 
 ## What it does
 
-Authentication owns **user identities** — email/password credentials, hashed with Argon2id — and the **token lifecycle**. Clients trade credentials (or nothing, for an anonymous session) for a short-lived access token and a long-lived refresh token, then refresh the pair without re-authenticating. Every account carries a role (`auth:anon`, `auth:user`, `auth:admin`, `auth:superadmin`); roles map to permissions that downstream services enforce per route.
+Authentication owns **user identities** — email/password credentials, hashed with Argon2id — and the **token lifecycle**. Clients trade credentials (or nothing, for an anonymous session) for a short-lived access token and a long-lived refresh token, then refresh the pair without re-authenticating. Every account carries a role, and each role maps to a set of permissions that downstream services enforce per route.
 
 Identity changes — registration, email change, password reset — are gated by single-use **short codes** emailed to the user, so a stolen session token alone can't take over an account.
 
@@ -55,7 +55,7 @@ services:
       - authentication-postgres-data:/var/lib/postgresql/
 
   migrations-authentication:
-    image: ghcr.io/a-novel/service-authentication/jobs/migrations:v2.4.2
+    image: ghcr.io/a-novel/service-authentication/jobs/migrations:v2.4.3
     depends_on:
       postgres-authentication: { condition: service_healthy }
     environment:
@@ -64,7 +64,7 @@ services:
 
   # Optional: seeds the initial super-admin user. Pass the credentials securely.
   init-authentication:
-    image: ghcr.io/a-novel/service-authentication/jobs/init:v2.4.2
+    image: ghcr.io/a-novel/service-authentication/jobs/init:v2.4.3
     depends_on:
       postgres-authentication: { condition: service_healthy }
       migrations-authentication: { condition: service_completed_successfully }
@@ -107,8 +107,6 @@ Every variable is read from the process environment.
 | `SERVICE_JSON_KEYS_PORT` | gRPC port of the JSON Keys service. **Required** on the server.                                                                 | `rest`<br/>`standalone-rest`                                       |
 | `SUPER_ADMIN_EMAIL`      | Email of the super-admin to provision. The bootstrap is skipped if unset.                                                       | `jobs/init`<br/>`standalone-rest`                                  |
 | `SUPER_ADMIN_PASSWORD`   | Plaintext password for the super-admin. Pass it securely. The bootstrap is skipped if unset.                                    | `jobs/init`<br/>`standalone-rest`                                  |
-
-Authentication and JSON Keys exchange sensitive data, so the link between them must run on a secure, unexposed network.
 
 <details>
 <summary>Optional configuration (client platform, SMTP, REST tuning, OpenTelemetry)</summary>

--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -1,14 +1,10 @@
-// Command init bootstraps the super-admin credentials from environment variables. It is
-// idempotent and safe to run on every deploy:
+// Command init reconciles the super-admin account with the credentials given in
+// SUPER_ADMIN_EMAIL and SUPER_ADMIN_PASSWORD. It is idempotent and safe to run on every
+// deploy: a missing account is created with the super-admin role, and an existing account
+// whose password or role has drifted is brought back in line.
 //
-//   - If no account exists for SUPER_ADMIN_EMAIL, a new one is created with the super-admin
-//     role and the configured password.
-//   - If an account exists with a different password, the password is updated.
-//   - If an account exists with a non-super-admin role, the role is upgraded.
-//
-// If either SUPER_ADMIN_EMAIL or SUPER_ADMIN_PASSWORD is empty, the command logs a warning
-// and exits cleanly without attempting any database changes — useful for environments where
-// the bootstrap step is intentionally disabled.
+// When either variable is empty the command logs a warning and exits without touching the
+// database, so the bootstrap step can be disabled by leaving the variables unset.
 package main
 
 import (

--- a/cmd/migrations/main.go
+++ b/cmd/migrations/main.go
@@ -23,11 +23,9 @@ func main() {
 
 	start := time.Now()
 
-	// Inventory the .up.sql files up-front so the recap can say how
-	// many migrations were discovered (the underlying helper uses
-	// uptrace/bun's Migrate, which doesn't expose a count without
-	// invasive wrapping — counting the embed.FS is the simplest
-	// stable approximation).
+	// Inventory the .up.sql files up-front so the recap can report how many were found.
+	// bun's migrator (used by RunMigrationsContext) exposes no count, so walking the
+	// embed.FS is the simplest stable approximation.
 	discovered := listUpMigrations(migrations.Migrations)
 	log.Printf("discovered %d migration(s) in models/migrations", len(discovered))
 
@@ -46,18 +44,16 @@ func main() {
 		len(discovered), time.Since(start).Round(time.Millisecond))
 }
 
-// listUpMigrations returns the bare names of every *.up.sql in the
-// migrations FS, sorted by their natural lexical order (timestamp
-// prefix guarantees chronological). Used for the start-of-run
-// inventory log; doesn't decide which are actually applied — bun's
-// migrator does that against the schema_migrations table.
+// listUpMigrations returns the bare name of every *.up.sql in f, in the lexical order
+// WalkDir yields (the timestamp prefix makes that chronological). It feeds the start-of-run
+// inventory log only; bun's migrator decides which migrations actually apply.
 func listUpMigrations(f fs.FS) []string {
 	var out []string
 
 	_ = fs.WalkDir(f, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			// Propagating aborts the walk; the caller discards the error —
-			// the inventory is best-effort logging, not a gate.
+			// Aborting the walk only skips inventory logging, not the migration run, so
+			// the caller discards this error.
 			return err
 		}
 

--- a/cmd/rest/main.go
+++ b/cmd/rest/main.go
@@ -1,3 +1,6 @@
+// Command rest runs the authentication service's HTTP API. It wires the data-access, core,
+// and handler layers together, mounts them on a chi router, and serves until an interrupt or
+// termination signal arrives, then shuts the server down gracefully.
 package main
 
 import (

--- a/internal/config/app.config.default.go
+++ b/internal/config/app.config.default.go
@@ -17,17 +17,22 @@ import (
 )
 
 const (
+	// OtelFlushTimeout bounds how long the process waits to flush buffered telemetry on shutdown.
 	OtelFlushTimeout = 2 * time.Second
 )
 
+// LoggerDev writes human-readable logs to stdout for local development.
 var LoggerDev = &loggingpresets.LogLocal{
 	Out: os.Stdout,
 }
 
+// LoggerProd emits structured logs for the Google Cloud Logging backend.
 var LoggerProd = &loggingpresets.LogGcloud{
 	ProjectId: env.GcloudProjectId,
 }
 
+// AppPresetDefault is the application configuration read from the environment, with each field falling
+// back to its documented default when the variable is unset.
 var AppPresetDefault = App{
 	App: Main{
 		Name: env.AppName,

--- a/internal/config/app.config.go
+++ b/internal/config/app.config.go
@@ -10,16 +10,19 @@ import (
 	"github.com/a-novel-kit/golib/smtp"
 )
 
+// Main holds the core identity of the service, used to tag its logs and traces.
 type Main struct {
 	Name string `json:"name" yaml:"name"`
 }
 
+// Dependencies configures how the service reaches the backing services it calls.
 type Dependencies struct {
 	ServiceJsonKeysHost        string                    `json:"jsonKeysServiceHost" yaml:"jsonKeysServiceHost"`
 	ServiceJsonKeysPort        int                       `json:"jsonKeysServicePort" yaml:"jsonKeysServicePort"`
 	ServiceJsonKeysCredentials grpcf.CredentialsProvider `json:"-"                   yaml:"-"`
 }
 
+// RestTimeouts bounds the phases of the REST server's request lifecycle.
 type RestTimeouts struct {
 	Read       time.Duration `json:"read"       yaml:"read"`
 	ReadHeader time.Duration `json:"readHeader" yaml:"readHeader"`
@@ -28,6 +31,7 @@ type RestTimeouts struct {
 	Request    time.Duration `json:"request"    yaml:"request"`
 }
 
+// Cors configures the cross-origin resource sharing policy of the REST server.
 type Cors struct {
 	AllowedOrigins   []string `json:"allowedOrigins"   yaml:"allowedOrigins"`
 	AllowedHeaders   []string `json:"allowedHeaders"   yaml:"allowedHeaders"`
@@ -35,6 +39,7 @@ type Cors struct {
 	MaxAge           int      `json:"maxAge"           yaml:"maxAge"`
 }
 
+// Rest configures the public REST HTTP server.
 type Rest struct {
 	Port           int          `json:"port"           yaml:"port"`
 	Timeouts       RestTimeouts `json:"timeouts"       yaml:"timeouts"`
@@ -42,6 +47,7 @@ type Rest struct {
 	Cors           Cors         `json:"cors"           yaml:"cors"`
 }
 
+// App is the fully resolved configuration for the service, assembled at startup from the environment.
 type App struct {
 	App  Main `json:"app"  yaml:"app"`
 	Rest Rest `json:"rest" yaml:"rest"`

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -4,6 +4,6 @@
 // observability) and the defaults applied when an environment variable is unset.
 //
 // The env subpackage parses the process environment into the [App] struct;
-// configtest exposes a fixture builder for tests. Runtime code should depend on
+// configtest exposes shared fixtures for tests. Runtime code should depend on
 // the typed structs declared here rather than reading os.Getenv directly.
 package config

--- a/internal/config/env/env.go
+++ b/internal/config/env/env.go
@@ -7,9 +7,8 @@ import (
 	"github.com/a-novel-kit/golib/config"
 )
 
-// prefix allows to set a custom prefix to all configuration environment variables.
-// This is useful when importing the package in another project, when env variable names
-// might conflict with the source project.
+// prefix is prepended to every configuration environment variable name. It lets a project that
+// embeds this package namespace the variables so they do not clash with its own.
 var prefix = os.Getenv("SERVICE_AUTHENTICATION_ENV_PREFIX")
 
 func getEnv(name string) string {
@@ -88,7 +87,7 @@ var (
 )
 
 var (
-	// PostgresDsn is the url used to connect to the postgres database instance.
+	// PostgresDsn is the URL used to connect to the Postgres database instance.
 	// Typically formatted as:
 	//	postgres://<user>:<password>@<host>:<port>/<database>
 	PostgresDsn = postgresDsn
@@ -126,33 +125,33 @@ var (
 	// See https://github.com/a-novel/service-json-keys
 	ServiceJsonKeysPort = config.LoadEnv(serviceJsonKeysPort, ServiceJsonKeysPortDefault, config.IntParser)
 
-	// SmtpAddr is the address of the SMTP service used to send mails.
+	// SmtpAddr is the address of the SMTP server used to send emails.
 	//
 	// It should be in the form domain:port.
 	SmtpAddr = smtpAddr
-	// SmtpSenderName defines the name that will appear as the sender in outgoing emails.
+	// SmtpSenderName is the display name that appears as the sender on outgoing emails.
 	SmtpSenderName = smtpSenderName
-	// SmtpSenderEmail is the email address used to send outgoing smtp emails.
+	// SmtpSenderEmail is the address outgoing emails are sent from.
 	SmtpSenderEmail = smtpSenderEmail
-	// SmtpSenderPassword is the plain password used to connect to the SmtpSenderEmail account. This is a sensitive
-	// value that should be handled appropriately.
+	// SmtpSenderPassword is the plain password used to authenticate the SmtpSenderEmail account. It is a sensitive
+	// value and should be handled accordingly.
 	SmtpSenderPassword = smtpSenderPassword
-	// SmtpSenderDomain is the domain used for sending Smtp emails. It should match the hostname of the SmtpAddr.
+	// SmtpSenderDomain is the domain used when sending emails. It should match the host of SmtpAddr.
 	SmtpSenderDomain = smtpSenderDomain
-	// SmtpTimeout is the timeout value when attempting to send an email.
+	// SmtpTimeout bounds how long a single email send may take.
 	SmtpTimeout = config.LoadEnv(smtpTimeout, SmtpTimeoutDefault, config.DurationParser)
-	// SmtpForceUnencrypted hacks the smtp client into sending plain credentials over any connection. This setting is
-	// used because the Go Smtp implementation refuses to send plain credentials over non-TLS connections, except for
-	// localhost. But because we use Docker, localhost is not always the name of our actual local host.
+	// SmtpForceUnencrypted forces the SMTP client to send plain credentials over any connection. Go's SMTP client
+	// refuses to send plain credentials over a non-TLS connection except to localhost, and under Docker the mail host
+	// is rarely reachable as localhost, so this override is needed for local runs.
 	//
-	// This setting MUST NEVER be set in production.
+	// It must never be set in production.
 	SmtpForceUnencrypted = config.LoadEnv(smtpForceUnencrypted, false, config.BoolParser)
 
 	// AppName is the name of the application, as it will appear in logs and tracing.
 	AppName = config.LoadEnv(appName, AppNameDefault, config.StringParser)
-	// Otel flag configures whether to use Open Telemetry or not.
+	// Otel enables OpenTelemetry instrumentation.
 	//
-	// See: https://opentelemetry.io/
+	// See https://opentelemetry.io/
 	Otel = config.LoadEnv(otel, false, config.BoolParser)
 
 	// RestPort is the port on which the rest server will listen for incoming requests.
@@ -177,7 +176,7 @@ var (
 	// See: https://docs.cloud.google.com/resource-manager/docs/creating-managing-projects
 	GcloudProjectId = gcloudProjectId
 	// SuperAdminEmail sets the email address for the default super-admin on the platform. Unlike other accounts,
-	// its email does not require to be validated.
+	// its email does not need to be validated.
 	SuperAdminEmail = superAdminEmail
 	// SuperAdminPassword sets the password for the default super-admin on the platform.
 	SuperAdminPassword = superAdminPassword

--- a/internal/config/lang.go
+++ b/internal/config/lang.go
@@ -1,8 +1,11 @@
 package config
 
 const (
+	// LangFR is the French language code.
 	LangFR = "fr"
+	// LangEN is the English language code.
 	LangEN = "en"
 )
 
+// KnownLangs lists every language code the service can render content in.
 var KnownLangs = []string{LangFR, LangEN}

--- a/internal/config/permissions.config.default.go
+++ b/internal/config/permissions.config.default.go
@@ -11,4 +11,7 @@ import (
 //go:embed permissions.config.yaml
 var defaultPermissionsFile []byte
 
+// PermissionsConfigDefault is the built-in role/permission map, loaded from the
+// embedded permissions.config.yaml. It applies when no custom permission set is
+// supplied.
 var PermissionsConfigDefault = config.MustUnmarshal[Permissions](yaml.Unmarshal, defaultPermissionsFile)

--- a/internal/config/permissions.config.go
+++ b/internal/config/permissions.config.go
@@ -4,25 +4,33 @@ import (
 	_ "embed"
 )
 
-// Role manages a set of permissions for a given Role.
+// A Role bundles the permissions granted to its holders. A role may inherit other
+// roles to accumulate their permissions, and its priority ranks it against the rest
+// of the hierarchy.
 type Role struct {
-	// Inherits the permissions from every listed role. Circular dependencies between roles are not allowed.
-	Inherits []string `json:"inherits" yaml:"inherits"`
-	// The set of permissions for the current role.
+	// Inherits pulls in the permissions of every listed role. Circular inheritance
+	// between roles is not allowed.
+	Inherits    []string `json:"inherits"    yaml:"inherits"`
 	Permissions []string `json:"permissions" yaml:"permissions"`
-	// The hierarchy level of this role. Roles with higher priorities are leaders, and the ones with lower
-	// priorities are subordinates.
+	// Priority ranks this role in the hierarchy; a higher value outranks a lower one.
 	Priority int `json:"priority" yaml:"priority"`
 }
 
+// Built-in role identifiers. Each matches a key in the permissions map, and they
+// grant progressively more access.
 const (
-	RoleAnon       = "auth:anon"
-	RoleUser       = "auth:user"
-	RoleAdmin      = "auth:admin"
+	// RoleAnon is the unauthenticated caller.
+	RoleAnon = "auth:anon"
+	// RoleUser is an authenticated standard user.
+	RoleUser = "auth:user"
+	// RoleAdmin is an operator with elevated access.
+	RoleAdmin = "auth:admin"
+	// RoleSuperAdmin holds the highest level of access.
 	RoleSuperAdmin = "auth:superadmin"
 )
 
-// Permissions maps every Role to a set of permissions.
+// Permissions is the role/permission configuration: it maps each role identifier
+// to its Role definition.
 type Permissions struct {
 	Roles map[string]Role `json:"roles" yaml:"roles"`
 }

--- a/internal/config/postgres.config.default.go
+++ b/internal/config/postgres.config.default.go
@@ -8,4 +8,6 @@ import (
 	"github.com/a-novel/service-authentication/v2/internal/config/env"
 )
 
+// PostgresPresetDefault is the default Postgres connection preset, built from the
+// DSN read from the environment.
 var PostgresPresetDefault = postgrespresets.NewDefault(pgdriver.WithDSN(env.PostgresDsn))

--- a/internal/config/short_codes.config.default.go
+++ b/internal/config/short_codes.config.default.go
@@ -11,4 +11,6 @@ import (
 //go:embed short_codes.config.yaml
 var defaultShortCodesFile []byte
 
+// ShortCodesPresetDefault is the default short-code configuration, loaded from the
+// embedded short_codes.config.yaml.
 var ShortCodesPresetDefault = config.MustUnmarshal[ShortCodes](yaml.Unmarshal, defaultShortCodesFile)

--- a/internal/config/short_codes.config.go
+++ b/internal/config/short_codes.config.go
@@ -5,11 +5,17 @@ import (
 	"time"
 )
 
+// ShortCodeUsage holds the settings for a single short-code usage.
 type ShortCodeUsage struct {
+	// TTL is how long a short code issued for this usage stays valid.
 	TTL time.Duration `json:"ttl" yaml:"ttl"`
 }
 
+// ShortCodes configures the one-time codes emailed to users to authorize sensitive
+// actions such as registration, email changes, and password resets.
 type ShortCodes struct {
-	Size   int                       `json:"size"   yaml:"size"`
+	// Size is the character length of a generated code.
+	Size int `json:"size" yaml:"size"`
+	// Usages holds the per-usage settings, keyed by usage name.
 	Usages map[string]ShortCodeUsage `json:"usages" yaml:"usages"`
 }

--- a/internal/config/smtp.go
+++ b/internal/config/smtp.go
@@ -2,6 +2,7 @@ package config
 
 import "time"
 
+// SmtpUrls configures the web-client links embedded in outgoing emails and the timeout for sending them.
 type SmtpUrls struct {
 	UpdateEmail    string        `json:"updateEmail"    yaml:"updateEmail"`
 	UpdatePassword string        `json:"updatePassword" yaml:"updatePassword"`

--- a/internal/core/credentials.go
+++ b/internal/core/credentials.go
@@ -9,6 +9,9 @@ import (
 	"github.com/a-novel/service-authentication/v2/internal/config"
 )
 
+// Credentials is a user account as the core layer exposes it: identity, email,
+// current role, and audit timestamps. The stored password hash stays in the DAO
+// layer and is never carried on this type.
 type Credentials struct {
 	ID        uuid.UUID
 	Email     string
@@ -17,6 +20,9 @@ type Credentials struct {
 	UpdatedAt time.Time
 }
 
+// ValidateCredentialsRole is a go-playground/validator field-level validator that
+// accepts a string only when it names a role defined in the default permissions
+// configuration. It is registered under the "role" tag at package init.
 func ValidateCredentialsRole(fl validator.FieldLevel) bool {
 	val := fl.Field().String()
 	for role := range config.PermissionsConfigDefault.Roles {

--- a/internal/core/credentialsCreate.go
+++ b/internal/core/credentialsCreate.go
@@ -89,7 +89,6 @@ func (service *CredentialsCreate) Exec(ctx context.Context, request *Credentials
 		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
 	}
 
-	// Encrypt the password.
 	encryptedPassword, err := lib.GenerateArgon2(request.Password, lib.Argon2ParamsDefault)
 	if err != nil {
 		return nil, otel.ReportError(span, fmt.Errorf("encrypt password: %w", err))

--- a/internal/core/credentialsCreateSuperAdmin.go
+++ b/internal/core/credentialsCreateSuperAdmin.go
@@ -30,11 +30,16 @@ type CredentialsCreateSuperAdminDaoUpdateRole interface {
 	Exec(ctx context.Context, request *dao.CredentialsUpdateRoleRequest) (*dao.Credentials, error)
 }
 
+// CredentialsCreateSuperAdminRequest carries the email and password of the
+// super-admin account to provision.
 type CredentialsCreateSuperAdminRequest struct {
 	Email    string `validate:"required,email,max=1024"`
 	Password string `validate:"required,min=4,max=1024"`
 }
 
+// CredentialsCreateSuperAdmin idempotently provisions a super-admin account for
+// bootstrap. Given an email and password it creates the account when absent, and
+// otherwise resets that account's password and raises its role to super-admin.
 type CredentialsCreateSuperAdmin struct {
 	dao               CredentialsCreateSuperAdminDao
 	daoSelect         CredentialsCreateSuperAdminDaoSelect
@@ -56,6 +61,10 @@ func NewCredentialsCreateSuperAdmin(
 	}
 }
 
+// Exec provisions the super-admin account described by the request, running the
+// lookup and the create-or-update in one transaction. The password is hashed with
+// Argon2id before storage. An existing account keeps its identity and creation
+// time; only its password and, when needed, its role are updated.
 func (service *CredentialsCreateSuperAdmin) Exec(
 	ctx context.Context, request *CredentialsCreateSuperAdminRequest,
 ) (*Credentials, error) {
@@ -96,7 +105,7 @@ func (service *CredentialsCreateSuperAdmin) Exec(
 
 			return nil
 		}
-		// If the error was not found, we already returned, so an error here is unexpected.
+		// The not-found case returned above; any error remaining here is a real lookup failure.
 		if err != nil {
 			return err
 		}

--- a/internal/core/credentialsExist.go
+++ b/internal/core/credentialsExist.go
@@ -20,6 +20,8 @@ type CredentialsExistRequest struct {
 	Email string `validate:"required,email,max=1024"`
 }
 
+// CredentialsExist reports whether an account is already registered for a given
+// email, letting callers reject duplicate registrations before doing further work.
 type CredentialsExist struct {
 	dao CredentialsExistDao
 }

--- a/internal/core/credentialsGet.go
+++ b/internal/core/credentialsGet.go
@@ -20,6 +20,7 @@ type CredentialsGetRequest struct {
 	ID uuid.UUID
 }
 
+// CredentialsGet retrieves a single account by its ID.
 type CredentialsGet struct {
 	dao CredentialsGetDao
 }

--- a/internal/core/credentialsList.go
+++ b/internal/core/credentialsList.go
@@ -23,6 +23,8 @@ type CredentialsListRequest struct {
 	Roles  []string `validate:"min=0,max=10,dive,role"`
 }
 
+// CredentialsList returns a paginated page of accounts, optionally narrowed to a
+// set of roles.
 type CredentialsList struct {
 	dao CredentialsListDao
 }

--- a/internal/core/credentialsUpdateEmail.go
+++ b/internal/core/credentialsUpdateEmail.go
@@ -29,6 +29,9 @@ type CredentialsUpdateEmailRequest struct {
 	ShortCode string `validate:"required,max=1024"`
 }
 
+// CredentialsUpdateEmail applies an email change confirmed by a short code. The
+// caller does not supply the new address directly: it is carried in the short-code
+// payload, so only the address the code was issued for can take effect.
 type CredentialsUpdateEmail struct {
 	dao                     CredentialsUpdateEmailDao
 	serviceShortCodeConsume CredentialsUpdateEmailServiceShortCodeConsume

--- a/internal/core/credentialsUpdatePassword.go
+++ b/internal/core/credentialsUpdatePassword.go
@@ -38,6 +38,9 @@ type CredentialsUpdatePasswordRequest struct {
 	UserID          uuid.UUID
 }
 
+// CredentialsUpdatePassword changes an account's password through one of two
+// authenticated paths: a reset short code proving the caller owns the account's
+// email, or the current password proving an active session belongs to the owner.
 type CredentialsUpdatePassword struct {
 	dao                     CredentialsUpdatePasswordDao
 	daoCredentialsSelect    CredentialsUpdatePasswordDaoCredentialsSelect
@@ -69,7 +72,6 @@ func (service *CredentialsUpdatePassword) Exec(
 		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
 	}
 
-	// Encrypt the new password.
 	encryptedPassword, err := lib.GenerateArgon2(request.Password, lib.Argon2ParamsDefault)
 	if err != nil {
 		return nil, otel.ReportError(span, fmt.Errorf("encrypt password: %w", err))
@@ -77,14 +79,12 @@ func (service *CredentialsUpdatePassword) Exec(
 
 	var credentials *dao.Credentials
 
-	// Password update supports two authentication paths, running within a transaction
-	// to ensure atomicity of verification and update.
+	// Verification and update share one transaction so a failed check never leaves a
+	// changed password behind.
 	err = postgres.RunInTx(ctx, nil, func(ctx context.Context, tx bun.IDB) error {
 		switch {
-		// Path 1: Password Reset Flow
-		// Used when the user forgot their password and requested a reset via email.
-		// The short code proves the user owns the email address associated with this account.
-		// This path does NOT require knowing the current password.
+		// Reset path: the short code proves the caller owns the account's email, so no
+		// current password is required.
 		case request.ShortCode != "":
 			_, err = service.serviceShortCodeConsume.Exec(ctx, &ShortCodeConsumeRequest{
 				Usage:  ShortCodeUsageResetPassword,
@@ -95,10 +95,8 @@ func (service *CredentialsUpdatePassword) Exec(
 				return fmt.Errorf("consume short code: %w", err)
 			}
 
-		// Path 2: Authenticated Password Change
-		// Used when a logged-in user wants to change their password.
-		// Requires the current password as proof of identity, preventing
-		// attackers with session access from locking out the legitimate user.
+		// Change path: verifying the current password stops someone holding only a live
+		// session from locking the owner out of their own account.
 		case request.CurrentPassword != "":
 			credentials, err = service.daoCredentialsSelect.Exec(
 				ctx,
@@ -114,7 +112,6 @@ func (service *CredentialsUpdatePassword) Exec(
 			}
 		}
 
-		// Update the password with the new Argon2 hash.
 		credentials, err = service.dao.Exec(ctx, &dao.CredentialsUpdatePasswordRequest{
 			ID:       request.UserID,
 			Password: encryptedPassword,

--- a/internal/core/credentialsUpdateRole.go
+++ b/internal/core/credentialsUpdateRole.go
@@ -45,6 +45,9 @@ type CredentialsUpdateRoleRequest struct {
 	Role          string `validate:"required,role"`
 }
 
+// CredentialsUpdateRole changes a target user's role on behalf of an acting user,
+// enforcing the role hierarchy: an actor cannot change its own role, promote anyone
+// above its own rank, or demote a user whose rank is at or above its own.
 type CredentialsUpdateRole struct {
 	dao                  CredentialsUpdateRoleDao
 	daoCredentialsSelect CredentialsUpdateRoleDaoCredentialsSelect

--- a/internal/core/refreshToken.go
+++ b/internal/core/refreshToken.go
@@ -2,11 +2,16 @@ package core
 
 import "github.com/google/uuid"
 
+// RefreshTokenClaims is the JWT payload of a refresh token: the token's own JTI and
+// the user it authenticates. The token-refresh flow matches Jti against an access
+// token's RefreshTokenID to bind the pair. See AccessTokenClaims for the binding.
 type RefreshTokenClaims struct {
 	Jti    string    `json:"jti,omitempty"`
 	UserID uuid.UUID `json:"userID,omitempty"`
 }
 
+// RefreshTokenClaimsForm is the payload submitted to the signer to mint a refresh
+// token. The JTI is assigned by the signer, so only the user ID is supplied here.
 type RefreshTokenClaimsForm struct {
 	UserID uuid.UUID `json:"userID,omitempty"`
 }

--- a/internal/core/shortCodeConsume.go
+++ b/internal/core/shortCodeConsume.go
@@ -26,24 +26,36 @@ var (
 	ErrShortCodeConsumeExpired = errors.New("short code expired")
 )
 
+// ShortCodeConsumeDaoSelect loads the stored short code for a (Usage, Target)
+// pair so the submitted code can be verified against it.
 type ShortCodeConsumeDaoSelect interface {
 	Exec(ctx context.Context, request *dao.ShortCodeSelectRequest) (*dao.ShortCode, error)
 }
+
+// ShortCodeConsumeDaoDelete retires a short code once it has been redeemed, so it
+// cannot be used a second time.
 type ShortCodeConsumeDaoDelete interface {
 	Exec(ctx context.Context, request *dao.ShortCodeDeleteRequest) (*dao.ShortCode, error)
 }
 
+// ShortCodeConsumeRequest identifies the code to redeem: the flow it was issued
+// for, the subject it was bound to, and the plaintext code the user supplied.
 type ShortCodeConsumeRequest struct {
 	Usage  string `validate:"required,usage"`
 	Target string `validate:"required,max=1024"`
 	Code   string `validate:"required,max=1024"`
 }
 
+// ShortCodeConsume verifies a user-submitted short code against the stored hash
+// and, on success, retires it so it cannot be redeemed twice. It is the
+// counterpart to [ShortCodeCreate].
 type ShortCodeConsume struct {
 	daoSelect ShortCodeConsumeDaoSelect
 	daoDelete ShortCodeConsumeDaoDelete
 }
 
+// NewShortCodeConsume wires the consume service to the DAOs that read and delete
+// stored codes.
 func NewShortCodeConsume(
 	daoSelect ShortCodeConsumeDaoSelect,
 	daoDelete ShortCodeConsumeDaoDelete,
@@ -54,6 +66,9 @@ func NewShortCodeConsume(
 	}
 }
 
+// Exec verifies the submitted code and, on success, deletes it and returns the
+// consumed [ShortCode]. It returns [ErrShortCodeConsumeInvalid] when the code does
+// not match the stored hash and [ErrShortCodeConsumeExpired] when it has lapsed.
 func (service *ShortCodeConsume) Exec(
 	ctx context.Context, request *ShortCodeConsumeRequest,
 ) (*ShortCode, error) {
@@ -87,7 +102,7 @@ func (service *ShortCodeConsume) Exec(
 		return nil, otel.ReportError(span, ErrShortCodeConsumeExpired)
 	}
 
-	// Compare the encrypted code with the plain code of the request.
+	// Compare the submitted code against the stored Argon2id hash.
 	err = lib.CompareArgon2(request.Code, entity.Code)
 	if err != nil {
 		// lib.ErrInvalidPassword is the expected outcome (mistyped / stale code, handler → 4xx);

--- a/internal/core/shortCodeCreate.go
+++ b/internal/core/shortCodeCreate.go
@@ -17,26 +17,33 @@ import (
 	"github.com/a-novel/service-authentication/v2/internal/lib"
 )
 
+// ShortCodeCreateDao persists a new short code and returns the stored row.
 type ShortCodeCreateDao interface {
 	Exec(ctx context.Context, request *dao.ShortCodeInsertRequest) (*dao.ShortCode, error)
 }
 
+// ShortCodeCreateRequest describes a code to issue: the flow it is for, the
+// subject it binds to, any flow-specific data to carry, and how long it lives.
 type ShortCodeCreateRequest struct {
 	Usage  string `validate:"required,usage"`
 	Target string `validate:"required,max=1024"`
 	Data   any
 	TTL    time.Duration `validate:"required"`
 
-	// Whe true, automatically expires any existing short code with the same target and usage.
-	// Otherwise, the presence of a duplicate will trigger an error.
+	// When true, any existing code for the same target and usage is expired and
+	// replaced; when false, a duplicate makes the request fail.
 	Override bool
 }
 
+// ShortCodeCreate issues a short code: it generates a random plaintext code,
+// stores only its Argon2id hash, and returns the plaintext once so the caller can
+// deliver it to the target. [ShortCodeConsume] redeems it.
 type ShortCodeCreate struct {
 	dao    ShortCodeCreateDao
 	config config.ShortCodes
 }
 
+// NewShortCodeCreate wires the create service to its DAO and short-code configuration.
 func NewShortCodeCreate(
 	dao ShortCodeCreateDao,
 	config config.ShortCodes,
@@ -47,6 +54,8 @@ func NewShortCodeCreate(
 	}
 }
 
+// Exec issues a new short code and returns it with the plaintext populated in
+// [ShortCode.PlainCode]; only the hash is stored.
 func (service *ShortCodeCreate) Exec(
 	ctx context.Context, request *ShortCodeCreateRequest,
 ) (*ShortCode, error) {
@@ -64,7 +73,7 @@ func (service *ShortCodeCreate) Exec(
 		return nil, otel.ReportError(span, fmt.Errorf("generate short code: %w", err))
 	}
 
-	// Encrypt the short code in the database.
+	// Store only the Argon2id hash; the plaintext code never reaches the database.
 	encrypted, err := lib.GenerateArgon2(plainCode, lib.Argon2ParamsDefault)
 	if err != nil {
 		return nil, otel.ReportError(span, fmt.Errorf("encrypt short code: %w", err))

--- a/internal/core/shortCodeCreateEmailUpdate.go
+++ b/internal/core/shortCodeCreateEmailUpdate.go
@@ -19,22 +19,32 @@ import (
 	"github.com/a-novel/service-authentication/v2/internal/models/mails/assets"
 )
 
+// ShortCodeCreateEmailUpdateService issues the underlying short code; satisfied
+// by [ShortCodeCreate].
 type ShortCodeCreateEmailUpdateService interface {
 	Exec(ctx context.Context, request *ShortCodeCreateRequest) (*ShortCode, error)
 }
 
+// ShortCodeCreateEmailUpdateDao reports whether an email address is already
+// registered, so a change to an address already in use can be rejected.
 type ShortCodeCreateEmailUpdateDao interface {
 	Exec(ctx context.Context, request *dao.CredentialsSelectByEmailRequest) (*dao.Credentials, error)
 }
 
+// ShortCodeCreateEmailUpdateSmtp is the mailer used to deliver the confirmation code.
 type ShortCodeCreateEmailUpdateSmtp = smtp.Sender
 
+// ShortCodeCreateEmailUpdateRequest carries the user changing their address, the
+// new email to confirm, and the language of the confirmation mail.
 type ShortCodeCreateEmailUpdateRequest struct {
 	ID    uuid.UUID
 	Email string `validate:"required,email,max=1024"`
 	Lang  string `validate:"required,langs"`
 }
 
+// ShortCodeCreateEmailUpdate issues a [ShortCodeUsageValidateEmail] code for an
+// email-change confirmation and emails it to the prospective new address, after
+// rejecting the change if that address is already registered.
 type ShortCodeCreateEmailUpdate struct {
 	service          ShortCodeCreateEmailUpdateService
 	selectDao        ShortCodeCreateEmailUpdateDao
@@ -45,6 +55,8 @@ type ShortCodeCreateEmailUpdate struct {
 	wg sync.WaitGroup
 }
 
+// NewShortCodeCreateEmailUpdate wires the email-change flow to the short-code
+// service, the email-existence DAO, and the mailer.
 func NewShortCodeCreateEmailUpdate(
 	service ShortCodeCreateEmailUpdateService,
 	selectDao ShortCodeCreateEmailUpdateDao,
@@ -61,10 +73,14 @@ func NewShortCodeCreateEmailUpdate(
 	}
 }
 
+// Wait blocks until every in-flight confirmation email has finished sending, so
+// callers can drain pending deliveries before shutdown.
 func (service *ShortCodeCreateEmailUpdate) Wait() {
 	service.wg.Wait()
 }
 
+// Exec issues the confirmation code and schedules its delivery email, returning
+// the code immediately. It fails if the requested email is already registered.
 func (service *ShortCodeCreateEmailUpdate) Exec(
 	ctx context.Context, request *ShortCodeCreateEmailUpdateRequest,
 ) (*ShortCode, error) {
@@ -105,7 +121,8 @@ func (service *ShortCodeCreateEmailUpdate) Exec(
 		return nil, otel.ReportError(span, fmt.Errorf("create short code: %w", err))
 	}
 
-	// Sends the short code by mail, once the request is done (context terminated).
+	// Deliver the code by email in a detached goroutine: WithoutCancel keeps the
+	// send alive after the request context is cancelled, and Wait drains it on shutdown.
 	service.wg.Add(1)
 
 	go service.sendMail(context.WithoutCancel(ctx), request, shortCode)

--- a/internal/core/shortCodeCreatePasswordReset.go
+++ b/internal/core/shortCodeCreatePasswordReset.go
@@ -18,19 +18,30 @@ import (
 	"github.com/a-novel/service-authentication/v2/internal/models/mails/assets"
 )
 
+// ShortCodeCreatePasswordResetService issues the underlying short code; satisfied
+// by [ShortCodeCreate].
 type ShortCodeCreatePasswordResetService interface {
 	Exec(ctx context.Context, request *ShortCodeCreateRequest) (*ShortCode, error)
 }
+
+// ShortCodeCreatePasswordResetDao looks up the credentials for an email address,
+// which both confirms the account exists and yields the user ID to bind the code to.
 type ShortCodeCreatePasswordResetDao interface {
 	Exec(ctx context.Context, request *dao.CredentialsSelectByEmailRequest) (*dao.Credentials, error)
 }
+
+// ShortCodeCreatePasswordResetSmtp is the mailer used to deliver the reset code.
 type ShortCodeCreatePasswordResetSmtp = smtp.Sender
 
+// ShortCodeCreatePasswordResetRequest carries the account email to reset and the
+// language of the reset mail.
 type ShortCodeCreatePasswordResetRequest struct {
 	Email string `validate:"required,email,max=1024"`
 	Lang  string `validate:"required,langs"`
 }
 
+// ShortCodeCreatePasswordReset issues a [ShortCodeUsageResetPassword] code for an
+// existing account and emails it to the account's current address.
 type ShortCodeCreatePasswordReset struct {
 	service          ShortCodeCreatePasswordResetService
 	selectDao        ShortCodeCreatePasswordResetDao
@@ -41,6 +52,8 @@ type ShortCodeCreatePasswordReset struct {
 	wg sync.WaitGroup
 }
 
+// NewShortCodeCreatePasswordReset wires the password-reset flow to the short-code
+// service, the credentials lookup DAO, and the mailer.
 func NewShortCodeCreatePasswordReset(
 	service ShortCodeCreatePasswordResetService,
 	selectDao ShortCodeCreatePasswordResetDao,
@@ -57,10 +70,14 @@ func NewShortCodeCreatePasswordReset(
 	}
 }
 
+// Wait blocks until every in-flight reset email has finished sending, so callers
+// can drain pending deliveries before shutdown.
 func (service *ShortCodeCreatePasswordReset) Wait() {
 	service.wg.Wait()
 }
 
+// Exec issues the reset code and schedules its delivery email, returning the code
+// immediately. It fails if no account matches the requested email.
 func (service *ShortCodeCreatePasswordReset) Exec(
 	ctx context.Context, request *ShortCodeCreatePasswordResetRequest,
 ) (*ShortCode, error) {
@@ -95,7 +112,8 @@ func (service *ShortCodeCreatePasswordReset) Exec(
 		return nil, otel.ReportError(span, fmt.Errorf("create short code: %w", err))
 	}
 
-	// Sends the short code by mail, once the request is done (context terminated).
+	// Deliver the code by email in a detached goroutine: WithoutCancel keeps the
+	// send alive after the request context is cancelled, and Wait drains it on shutdown.
 	service.wg.Add(1)
 
 	go service.sendMail(context.WithoutCancel(ctx), request, credentials.ID, shortCode)

--- a/internal/core/shortCodeCreateRegister.go
+++ b/internal/core/shortCodeCreateRegister.go
@@ -18,21 +18,31 @@ import (
 	"github.com/a-novel/service-authentication/v2/internal/models/mails/assets"
 )
 
+// ShortCodeCreateRegisterService issues the underlying short code; satisfied by
+// [ShortCodeCreate].
 type ShortCodeCreateRegisterService interface {
 	Exec(ctx context.Context, request *ShortCodeCreateRequest) (*ShortCode, error)
 }
 
+// ShortCodeCreateRegisterDao reports whether an email address is already
+// registered, so a duplicate sign-up can be rejected.
 type ShortCodeCreateRegisterDao interface {
 	Exec(ctx context.Context, request *dao.CredentialsSelectByEmailRequest) (*dao.Credentials, error)
 }
 
+// ShortCodeCreateRegisterSmtp is the mailer used to deliver the registration code.
 type ShortCodeCreateRegisterSmtp = smtp.Sender
 
+// ShortCodeCreateRegisterRequest carries the address to register and the language
+// of the registration mail.
 type ShortCodeCreateRegisterRequest struct {
 	Email string `validate:"required,email,max=1024"`
 	Lang  string `validate:"required,langs"`
 }
 
+// ShortCodeCreateRegister issues a [ShortCodeUsageRegister] code for a new-account
+// sign-up and emails it to the prospective address, after rejecting the sign-up if
+// that address is already registered.
 type ShortCodeCreateRegister struct {
 	service          ShortCodeCreateRegisterService
 	selectDao        ShortCodeCreateRegisterDao
@@ -43,6 +53,8 @@ type ShortCodeCreateRegister struct {
 	wg sync.WaitGroup
 }
 
+// NewShortCodeCreateRegister wires the registration flow to the short-code
+// service, the email-existence DAO, and the mailer.
 func NewShortCodeCreateRegister(
 	service ShortCodeCreateRegisterService,
 	selectDao ShortCodeCreateRegisterDao,
@@ -59,10 +71,14 @@ func NewShortCodeCreateRegister(
 	}
 }
 
+// Wait blocks until every in-flight registration email has finished sending, so
+// callers can drain pending deliveries before shutdown.
 func (service *ShortCodeCreateRegister) Wait() {
 	service.wg.Wait()
 }
 
+// Exec issues the registration code and schedules its delivery email, returning
+// the code immediately. It fails if the address is already registered.
 func (service *ShortCodeCreateRegister) Exec(
 	ctx context.Context, request *ShortCodeCreateRegisterRequest,
 ) (*ShortCode, error) {
@@ -101,7 +117,8 @@ func (service *ShortCodeCreateRegister) Exec(
 		return nil, otel.ReportError(span, fmt.Errorf("create short code: %w", err))
 	}
 
-	// Sends the short code by mail, once the request is done (context terminated).
+	// Deliver the code by email in a detached goroutine: WithoutCancel keeps the
+	// send alive after the request context is cancelled, and Wait drains it on shutdown.
 	service.wg.Add(1)
 
 	go service.sendMail(context.WithoutCancel(ctx), request, shortCode)

--- a/internal/core/token.go
+++ b/internal/core/token.go
@@ -1,5 +1,7 @@
 package core
 
+// Token is a signed token pair returned by the core token operations. Anonymous
+// tokens (see TokenCreateAnon) fill only AccessToken and leave RefreshToken empty.
 type Token struct {
 	AccessToken  string
 	RefreshToken string

--- a/internal/core/tokenCreate.go
+++ b/internal/core/tokenCreate.go
@@ -36,9 +36,8 @@ type TokenCreateRequest struct {
 	Password string `validate:"required,max=1024"`
 }
 
-// TokenCreate implements the authentication service using a two-token system.
-// It issues both an access token (short-lived, for API authorization) and
-// a refresh token (long-lived, for obtaining new access tokens).
+// TokenCreate authenticates a user by email and password and issues a fresh
+// access/refresh token pair.
 type TokenCreate struct {
 	dao               TokenCreateDao
 	serviceSignClaims TokenCreateServiceSignClaims
@@ -54,16 +53,12 @@ func NewTokenCreate(
 	}
 }
 
-// Exec authenticates a user and returns a token pair.
+// Exec verifies the request's email and password and returns a freshly signed
+// access/refresh token pair. See signTokenPair for how the two tokens are bound.
 //
-// The two-token system works as follows:
-//   - Access Token: Short-lived JWT containing user ID, roles, and a reference to the refresh token.
-//     Used for API authorization via the Authorization header.
-//   - Refresh Token: Long-lived JWT used to obtain new access tokens without re-authentication.
-//     Contains only the user ID and is bound to the access token via its JTI.
-//
-// Returns ErrInvalidPassword if the password doesn't match, or dao.ErrCredentialsSelectByEmailNotFound
-// if the email is not registered.
+// It returns lib.ErrInvalidPassword when the password does not match and
+// dao.ErrCredentialsSelectByEmailNotFound when the email is not registered; both
+// surface as 401 at the handler.
 func (service *TokenCreate) Exec(
 	ctx context.Context, request *TokenCreateRequest,
 ) (*Token, error) {

--- a/internal/core/tokenCreateAnon.go
+++ b/internal/core/tokenCreateAnon.go
@@ -15,6 +15,9 @@ import (
 	"github.com/a-novel/service-authentication/v2/internal/config"
 )
 
+// anonTokenClaims is the fixed sign request for anonymous access tokens. The payload
+// never varies — no user ID, only the anonymous role — so it is marshaled once at
+// package load rather than per request.
 var anonTokenClaims = &servicejsonkeys.ClaimsSignRequest{
 	Usage: servicejsonkeys.KeyUsageAuth,
 	Payload: lo.Must(grpcf.MarshalJSONAsAny(AccessTokenClaims{
@@ -22,12 +25,15 @@ var anonTokenClaims = &servicejsonkeys.ClaimsSignRequest{
 	})),
 }
 
+// TokenCreateAnonSignClaimsService is the json-keys signing surface TokenCreateAnon needs.
 type TokenCreateAnonSignClaimsService interface {
 	ClaimsSign(
 		ctx context.Context, req *servicejsonkeys.ClaimsSignRequest, opts ...grpc.CallOption,
 	) (*servicejsonkeys.ClaimsSignResponse, error)
 }
 
+// TokenCreateAnon issues an anonymous access token, carrying no user ID and only the
+// anonymous role. See AccessTokenClaims for what such tokens grant.
 type TokenCreateAnon struct {
 	signClaimsService TokenCreateAnonSignClaimsService
 }

--- a/internal/core/tokenRefresh.go
+++ b/internal/core/tokenRefresh.go
@@ -44,26 +44,39 @@ var (
 	ErrTokenRefreshMismatchSource = errors.New("refresh token not issued from access token")
 )
 
+// TokenRefreshDao reloads the current credentials of the user being refreshed.
 type TokenRefreshDao interface {
 	Exec(ctx context.Context, request *dao.CredentialsSelectRequest) (*dao.Credentials, error)
 }
+
+// TokenRefreshServiceSignClaims signs the new access token.
 type TokenRefreshServiceSignClaims interface {
 	ClaimsSign(
 		ctx context.Context, req *servicejsonkeys.ClaimsSignRequest, opts ...grpc.CallOption,
 	) (*servicejsonkeys.ClaimsSignResponse, error)
 }
+
+// TokenRefreshServiceVerifyClaims verifies the incoming access token and decodes its
+// claims. It is distinct from TokenRefreshServiceVerifyRefreshClaims only in the claim
+// type it returns.
 type TokenRefreshServiceVerifyClaims interface {
 	VerifyClaims(ctx context.Context, req *servicejsonkeys.VerifyClaimsRequest) (*AccessTokenClaims, error)
 }
+
+// TokenRefreshServiceVerifyRefreshClaims verifies the incoming refresh token and decodes
+// its claims.
 type TokenRefreshServiceVerifyRefreshClaims interface {
 	VerifyClaims(ctx context.Context, req *servicejsonkeys.VerifyClaimsRequest) (*RefreshTokenClaims, error)
 }
 
+// TokenRefreshRequest carries the access/refresh token pair to be renewed.
 type TokenRefreshRequest struct {
 	AccessToken  string `validate:"required,max=1024"`
 	RefreshToken string `validate:"required,max=1024"`
 }
 
+// TokenRefresh renews an access token from a valid refresh token, minting a new access
+// token that reflects the user's current roles while reusing the same refresh token.
 type TokenRefresh struct {
 	dao                        TokenRefreshDao
 	serviceSignClaims          TokenRefreshServiceSignClaims
@@ -96,9 +109,8 @@ func (service *TokenRefresh) Exec(
 		return nil, otel.ReportError(span, errors.Join(err, ErrInvalidRequest))
 	}
 
-	// Step 1: Verify the access token signature.
-	// We allow expired tokens here because the whole point of refresh is to get a new access token
-	// after the old one expires. However, the signature must still be valid to prevent forgery.
+	// Verify the access token's signature. Expiry is ignored on purpose: renewing an
+	// expired access token is exactly what refresh is for, but the signature must hold.
 	accessTokenClaims, err := service.serviceVerifyClaims.VerifyClaims(
 		ctx,
 		&servicejsonkeys.VerifyClaimsRequest{
@@ -115,8 +127,7 @@ func (service *TokenRefresh) Exec(
 		return nil, otel.ReportError(span, err)
 	}
 
-	// Step 2: Verify the refresh token signature and expiration.
-	// Unlike access tokens, refresh tokens must not be expired.
+	// Verify the refresh token. Unlike the access token, it must not be expired.
 	refreshTokenClaims, err := service.serviceVerifyRefreshClaims.VerifyClaims(
 		ctx,
 		&servicejsonkeys.VerifyClaimsRequest{
@@ -137,8 +148,7 @@ func (service *TokenRefresh) Exec(
 		attribute.String("refreshTokenClaims.userID", refreshTokenClaims.UserID.String()),
 	)
 
-	// Step 3: Verify that both tokens belong to the same user.
-	// This prevents an attacker from using a stolen refresh token with a different user's access token.
+	// Both tokens must name the same user; see ErrTokenRefreshMismatchClaims.
 	if lo.FromPtr(accessTokenClaims.UserID) != refreshTokenClaims.UserID {
 		return nil, otel.ReportError(span, ErrTokenRefreshMismatchClaims)
 	}
@@ -148,16 +158,14 @@ func (service *TokenRefresh) Exec(
 		attribute.String("refreshTokenClaims.jti", refreshTokenClaims.Jti),
 	)
 
-	// Step 4: Verify that the access token was issued from this specific refresh token.
-	// Each access token stores the JTI of the refresh token that created it.
-	// This binding ensures that:
-	//   - An access token can only be refreshed using its original refresh token
-	//   - Revoking a refresh token effectively revokes all access tokens derived from it
+	// The access token must have been minted by this very refresh token — so revoking a
+	// refresh token also invalidates every access token minted from it. See
+	// ErrTokenRefreshMismatchSource for the binding this enforces.
 	if accessTokenClaims.RefreshTokenID != refreshTokenClaims.Jti {
 		return nil, otel.ReportError(span, ErrTokenRefreshMismatchSource)
 	}
 
-	// Retrieve updated credentials.
+	// Reload credentials so any role change since the original sign lands in the new token.
 	credentials, err := service.dao.Exec(ctx, &dao.CredentialsSelectRequest{
 		ID: lo.FromPtr(accessTokenClaims.UserID),
 	})

--- a/internal/dao/pg.credentials.go
+++ b/internal/dao/pg.credentials.go
@@ -7,7 +7,7 @@ import (
 	"github.com/uptrace/bun"
 )
 
-// Credentials represent the information used to authenticate and discriminate a user.
+// Credentials hold the information used to authenticate and identify a user.
 type Credentials struct {
 	bun.BaseModel `bun:"table:credentials"`
 

--- a/internal/dao/pg.credentialsExist.go
+++ b/internal/dao/pg.credentialsExist.go
@@ -20,9 +20,9 @@ type CredentialsExistRequest struct {
 	Email string
 }
 
-// CredentialsExist checks whether a user with a given email address exists or not.
+// CredentialsExist reports whether a user with the given email address exists.
 //
-// It does not return an error if the user does not exist, instead it returns a false boolean.
+// An absent user is not an error; the call returns false instead.
 type CredentialsExist struct{}
 
 func NewCredentialsExist() *CredentialsExist {

--- a/internal/dao/pg.credentialsInsert.go
+++ b/internal/dao/pg.credentialsInsert.go
@@ -24,6 +24,7 @@ var credentialsInsertQuery string
 // branch on it with errors.Is.
 var ErrCredentialsInsertAlreadyExists = errors.New("credentials already exists")
 
+// CredentialsInsertRequest is the input to [CredentialsInsert.Exec].
 type CredentialsInsertRequest struct {
 	// See Credentials.ID.
 	ID uuid.UUID

--- a/internal/dao/pg.credentialsList.go
+++ b/internal/dao/pg.credentialsList.go
@@ -15,9 +15,7 @@ import (
 //go:embed pg.credentialsList.sql
 var credentialsListQuery string
 
-// CredentialsListRequest is the input to [CredentialsList.Exec]. Pagination uses
-// limit/offset; an empty Roles slice disables the role filter and returns
-// credentials of every role.
+// CredentialsListRequest is the input to [CredentialsList.Exec].
 type CredentialsListRequest struct {
 	Limit  int
 	Offset int
@@ -47,8 +45,9 @@ func (dao *CredentialsList) Exec(
 	)
 
 	if len(request.Roles) == 0 {
-		// Make sure roles are defined in the query, to prevent type error.
-		// An empty array will still ignore roles filter like a nil value is expected to do.
+		// bun.List needs a non-nil slice to render a valid expression; a nil slice
+		// produces a type error. An empty slice renders as NULL, which the query
+		// treats as "no role filter".
 		request.Roles = []string{}
 	}
 

--- a/internal/dao/pg.shortCode.go
+++ b/internal/dao/pg.shortCode.go
@@ -7,18 +7,17 @@ import (
 	"github.com/uptrace/bun"
 )
 
-// ShortCode is used as a validation mechanism. It stores randomly generated temporary
-// passwords that can be used for various tasks, without requiring or without the possibility
-// for direct authentication.
+// ShortCode is a validation mechanism. It stores randomly generated, temporary
+// passwords used to authorize tasks that must not require direct authentication.
 //
-// Like passwords, short codes MUST be encrypted using one-way encryption (the original message
-// cannot be reverse-engineered). The clear value of the short code should be sent to the
-// client through a secure channel.
+// Like passwords, short codes are stored with one-way encryption: the original value
+// cannot be recovered from the stored one. The clear value is sent to the client
+// through a secure channel.
 //
-// A short-code should only ever be used once, It MUST BE discarded after a successful use.
+// A short code may only be used once, and is discarded after a successful use.
 //
-// Unlike most other entities, unique constraints only apply to non-expired, non-deleted
-// short codes. This mean those rules naturally evolve over time.
+// Unlike most other entities, the uniqueness constraint applies only to non-expired,
+// non-deleted short codes, so it naturally evolves over time.
 type ShortCode struct {
 	bun.BaseModel `bun:"table:short_codes"`
 
@@ -28,34 +27,26 @@ type ShortCode struct {
 	// validation.
 	Code string `bun:"code"`
 
-	// Usage of the short code, used to identify a short code along with the Target field.
-	// There can be only a single combination of Usage / Target among active short codes.
+	// Usage identifies the flow the short code is valid for. Together with Target it
+	// forms the pair that is unique among active short codes.
 	Usage string `bun:"usage"`
-	// Target of the short code, usually the channel used to send the clear code. It is
-	// used to identify a short code along with the Usage field.
-	// There can be only a single combination of Usage / Target among active short codes.
+	// Target identifies the subject of the operation, usually the channel the clear code
+	// was sent to. See Usage for the uniqueness rule on the pair.
 	Target string `bun:"target"`
 
 	// Additional data to use after validating a short code.
 	Data []byte `bun:"data"`
 
 	CreatedAt time.Time `bun:"created_at"`
-	// A short code, unlike a password, is sent in the wild (i.e. the clear version is
-	// persisted at the place it was sent). It is then important to make this short code
-	// as short-lived as possible, especially as it can be used to perform critical
-	// operations (e.g. password reset).
-	//
-	// The ExpiresAt value should be as close as possible in the future, usually a matter of days.
+	// ExpiresAt bounds the short code's lifetime. Unlike a password, the clear value
+	// lives wherever it was delivered, so the code is kept as short-lived as possible —
+	// usually a matter of days — to limit exposure, since it can authorize critical
+	// operations such as a password reset.
 	ExpiresAt time.Time `bun:"expires_at"`
 
-	// DeletedAt means the short code has been invalidated BEFORE its expiration.
-	// This can happen during a leakage (manual suppression by admins), but also happens
-	// naturally when:
-	//
-	//  - A short code is consumed (it can only be used once).
-	//  - A new short code with the same Target / Usage is created.
-	//
-	// The reason for a short code deletion is stated in the DeletedComment field.
+	// DeletedAt marks a short code invalidated before its expiration, either manually
+	// (an admin suppressing a leak) or naturally when the code is consumed or superseded
+	// by a newer code for the same Target / Usage pair. DeletedComment records the reason.
 	DeletedAt      *time.Time `bun:"deleted_at"`
 	DeletedComment *string    `bun:"deleted_comment"`
 }

--- a/internal/dao/pg.shortCodeDelete.sql
+++ b/internal/dao/pg.shortCodeDelete.sql
@@ -4,7 +4,7 @@ SET
   deleted_comment = ?1
 WHERE
   id = ?2
-  AND deleted_at IS NULL -- Short code must not be deleted
-  AND expires_at > CURRENT_TIMESTAMP -- Short code must not be expired
+  AND deleted_at IS NULL
+  AND expires_at > CURRENT_TIMESTAMP
 RETURNING
   *;

--- a/internal/dao/pg.shortCodeInsert.go
+++ b/internal/dao/pg.shortCodeInsert.go
@@ -31,11 +31,10 @@ var shortCodeInsertQuery string
 // layer caught the conflict.
 var ErrShortCodeInsertAlreadyExists = errors.New("short code already exists")
 
-// ShortCodeInsertRequest is the input to [ShortCodeInsert.Exec]. The dao
-// runs at REPEATABLE READ isolation; uniqueness on (target, usage) for the
-// active subset is enforced by the partial unique index added in the
-// 20260510140000 migration, so concurrent inserts cannot produce duplicates
-// (the loser sees [ErrShortCodeInsertAlreadyExists]).
+// ShortCodeInsertRequest is the input to [ShortCodeInsert.Exec]. The insert runs at
+// repeatable-read isolation, and uniqueness on the active (target, usage) subset is
+// backed by a partial unique index, so concurrent inserts cannot produce duplicates:
+// the loser sees [ErrShortCodeInsertAlreadyExists].
 type ShortCodeInsertRequest struct {
 	// See ShortCode.ID.
 	ID uuid.UUID
@@ -47,7 +46,7 @@ type ShortCodeInsertRequest struct {
 	Target string
 	// See ShortCode.Data.
 	Data []byte
-	// Time used for insertion date.
+	// Now is the timestamp recorded as the row's creation time.
 	Now time.Time
 	// See ShortCode.ExpiresAt.
 	ExpiresAt time.Time

--- a/internal/dao/pg.shortCodeSelect.go
+++ b/internal/dao/pg.shortCodeSelect.go
@@ -23,9 +23,8 @@ var shortCodeSelectQuery string
 // the dao layer can't distinguish: never-issued, expired, and already-consumed.
 var ErrShortCodeSelectNotFound = errors.New("short code not found")
 
-// ShortCodeSelectRequest is the input to [ShortCodeSelect.Exec]. At most one
-// non-deleted row exists per (Usage, Target) pair: the partial unique index
-// added in the 20260510140000 migration enforces this, so the query returns
+// ShortCodeSelectRequest is the input to [ShortCodeSelect.Exec]. A partial unique
+// index keeps at most one active row per (Usage, Target) pair, so the query returns
 // either zero or one row.
 type ShortCodeSelectRequest struct {
 	// Usage selects which flow this code is valid for; matches [ShortCode.Usage].

--- a/internal/handlers/doc.go
+++ b/internal/handlers/doc.go
@@ -3,7 +3,7 @@
 // Each handler wraps a single service: it decodes the HTTP request, calls
 // service.Exec, and translates the result (or error) into a status code and
 // body. Service-layer sentinel errors map to user-facing 4xx responses; any
-// other error surfaces as 500. The OpenAPI specification at the dao
+// other error surfaces as 500. The OpenAPI specification at the repository
 // root is the source of truth for request and response shapes — handlers
 // mirror it.
 package handlers

--- a/internal/handlers/middlewares/rest.auth.go
+++ b/internal/handlers/middlewares/rest.auth.go
@@ -45,6 +45,8 @@ type Auth struct {
 	logger logging.Log
 }
 
+// NewAuth returns an [Auth] that verifies access tokens with the given claims
+// verifier and resolves caller roles to permissions through permissionsByRole.
 func NewAuth(
 	claimsVerifier AuthClaimsVerifier,
 	permissionsByRole map[string][]string,
@@ -73,7 +75,7 @@ func (middleware *Auth) Middleware(requiredPermissions []string) func(http.Handl
 			defer span.End()
 
 			token := r.Header.Get("Authorization")
-			// No token but no permissions required.
+			// Optional-auth endpoint: no token supplied and none required, so pass through unauthenticated.
 			if token == "" && len(requiredPermissions) == 0 {
 				otel.ReportSuccessNoContent(span)
 				next.ServeHTTP(w, r.WithContext(ctx))
@@ -189,7 +191,7 @@ func GetClaimsContext(ctx context.Context) (*core.AccessTokenClaims, error) {
 }
 
 // MustGetClaimsContext retrieves the authenticated user's claims from the context.
-// Unlike GetClaimsContext, this returns an error if no claims are present,
+// Unlike [GetClaimsContext], this returns an error if no claims are present,
 // making it suitable for endpoints that require authentication.
 func MustGetClaimsContext(ctx context.Context) (*core.AccessTokenClaims, error) {
 	claims, err := GetClaimsContext(ctx)

--- a/internal/handlers/rest.claims.go
+++ b/internal/handlers/rest.claims.go
@@ -2,6 +2,8 @@ package handlers
 
 import "github.com/google/uuid"
 
+// Claims is the JSON body of the claims endpoint: the identity a valid access
+// token grants its bearer. UserID is nil for an anonymous token.
 type Claims struct {
 	UserID         *uuid.UUID `json:"userID,omitempty"`
 	Roles          []string   `json:"roles,omitempty"`

--- a/internal/handlers/rest.claimsGet.go
+++ b/internal/handlers/rest.claimsGet.go
@@ -10,10 +10,14 @@ import (
 	"github.com/a-novel/service-authentication/v2/internal/handlers/middlewares"
 )
 
+// ClaimsGet is the REST handler that returns the caller's own claims, read from
+// the request context where the authentication middleware deposits them. It
+// responds 403 when the request carries no resolved claims.
 type ClaimsGet struct {
 	logger logging.Log
 }
 
+// NewClaimsGet returns a ClaimsGet handler.
 func NewClaimsGet(logger logging.Log) *ClaimsGet {
 	return &ClaimsGet{logger: logger}
 }

--- a/internal/handlers/rest.credentials.go
+++ b/internal/handlers/rest.credentials.go
@@ -8,6 +8,8 @@ import (
 	"github.com/a-novel/service-authentication/v2/internal/core"
 )
 
+// Credentials is the JSON representation of a user's account record returned by
+// the credentials endpoints.
 type Credentials struct {
 	ID        uuid.UUID `json:"id"`
 	Email     string    `json:"email"`

--- a/internal/handlers/rest.credentialsExist.go
+++ b/internal/handlers/rest.credentialsExist.go
@@ -50,7 +50,8 @@ func (handler *CredentialsExist) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// The status is indicative, the query is considered successful from here.
+	// Reaching here means the lookup ran: a missing email is a normal result, not a span
+	// failure, even though it returns 404 below.
 	defer otel.ReportSuccess(span, ok)
 
 	if !ok {

--- a/internal/handlers/rest.decoder.go
+++ b/internal/handlers/rest.decoder.go
@@ -2,4 +2,7 @@ package handlers
 
 import "github.com/gorilla/schema"
 
+// muxDecoder decodes URL query parameters into request structs by their schema
+// tags. One shared instance suffices: a schema.Decoder is safe for concurrent
+// use once configured.
 var muxDecoder = schema.NewDecoder()

--- a/internal/handlers/rest.health.go
+++ b/internal/handlers/rest.health.go
@@ -40,8 +40,11 @@ func NewRestHealthStatus(err error) *RestHealthStatus {
 	}
 }
 
+// RestHealthClientSmtp is the SMTP sender whose reachability the health check probes.
 type RestHealthClientSmtp = smtp.Sender
 
+// RestHealthApiJsonKeys is the slice of the JSON-keys client the health check needs:
+// a Status probe used to confirm the upstream service answers.
 type RestHealthApiJsonKeys interface {
 	Status(
 		ctx context.Context,
@@ -50,11 +53,15 @@ type RestHealthApiJsonKeys interface {
 	) (*servicejsonkeys.StatusResponse, error)
 }
 
+// RestHealth is the handler backing /healthcheck. It probes each downstream
+// dependency and reports their combined status; see RestHealthStatus for why the
+// response withholds error detail.
 type RestHealth struct {
 	apiJsonKeys RestHealthApiJsonKeys
 	clientSmtp  RestHealthClientSmtp
 }
 
+// NewRestHealth returns a RestHealth handler wired to the dependencies it probes.
 func NewRestHealth(
 	apiJsonKeys RestHealthApiJsonKeys,
 	clientSmtp RestHealthClientSmtp,
@@ -87,7 +94,8 @@ func (handler *RestHealth) reportPostgres(ctx context.Context) error {
 
 	pgdb, ok := pg.(*bun.DB)
 	if !ok {
-		// Cannot assess db connection if we are running on transaction mode
+		// Inside a transaction the handle is not a *bun.DB and exposes no pool to
+		// ping, so there is nothing to probe; report healthy.
 		return nil
 	}
 

--- a/internal/handlers/rest.shortCodeCreateEmailUpdate.go
+++ b/internal/handlers/rest.shortCodeCreateEmailUpdate.go
@@ -65,8 +65,7 @@ func (handler *ShortCodeCreateEmailUpdate) ServeHTTP(w http.ResponseWriter, r *h
 		ID:    lo.FromPtr(claims.UserID),
 	})
 	if err != nil {
-		// Silently succeed if email already exists to prevent email enumeration.
-		// The user won't receive an email, but they won't know if the email was registered.
+		// Silently succeed when the email already exists, so a caller cannot probe which addresses are registered.
 		if !errors.Is(err, dao.ErrCredentialsUpdateEmailAlreadyExists) {
 			httpf.HandleError(ctx, handler.logger, w, span, httpf.ErrMap{
 				core.ErrInvalidRequest: http.StatusUnprocessableEntity,

--- a/internal/handlers/rest.shortCodeCreatePasswordReset.go
+++ b/internal/handlers/rest.shortCodeCreatePasswordReset.go
@@ -54,8 +54,7 @@ func (handler *ShortCodeCreatePasswordReset) ServeHTTP(w http.ResponseWriter, r 
 		Lang:  request.Lang,
 	})
 	if err != nil {
-		// Silently succeed if email not found to prevent email enumeration.
-		// The user won't receive an email, but they won't know if the email was registered.
+		// Silently succeed when the email is unknown, so a caller cannot probe which addresses are registered.
 		if !errors.Is(err, dao.ErrCredentialsSelectByEmailNotFound) {
 			httpf.HandleError(ctx, handler.logger, w, span, httpf.ErrMap{
 				core.ErrInvalidRequest: http.StatusUnprocessableEntity,

--- a/internal/handlers/rest.shortCodeCreateRegister.go
+++ b/internal/handlers/rest.shortCodeCreateRegister.go
@@ -52,8 +52,7 @@ func (handler *ShortCodeCreateRegister) ServeHTTP(w http.ResponseWriter, r *http
 		Lang:  request.Lang,
 	})
 	if err != nil {
-		// Silently succeed if email already exists to prevent email enumeration.
-		// The user won't receive an email, but they won't know if the email was registered.
+		// Silently succeed when the email already exists, so a caller cannot probe which addresses are registered.
 		if !errors.Is(err, dao.ErrCredentialsInsertAlreadyExists) {
 			httpf.HandleError(ctx, handler.logger, w, span, httpf.ErrMap{
 				core.ErrInvalidRequest: http.StatusUnprocessableEntity,

--- a/internal/handlers/rest.token.go
+++ b/internal/handlers/rest.token.go
@@ -2,6 +2,7 @@ package handlers
 
 import "github.com/a-novel/service-authentication/v2/internal/core"
 
+// Token is the access and refresh token pair returned by the token endpoints.
 type Token struct {
 	AccessToken  string `json:"accessToken"`
 	RefreshToken string `json:"refreshToken"`

--- a/internal/lib/argon2.go
+++ b/internal/lib/argon2.go
@@ -31,13 +31,14 @@ var (
 )
 
 const (
+	// Number of $-separated segments in an encoded Argon2id hash string, used to
+	// validate its shape before decoding.
 	argon2HashLen = 6
 )
 
-// Default parameters for Argon2id, following https://www.rfc-editor.org/rfc/rfc9106.html#section-7.4
-// recommendations.
-//
-// We use the second recommendation for resources optimization.
+// Default parameters for Argon2id, following the recommendations in RFC 9106
+// (https://www.rfc-editor.org/rfc/rfc9106.html#section-7.4). The second,
+// lower-memory configuration is used.
 const (
 	Argon2IterationsDefault = 3
 	Argon2MemoryDefault     = 64 * 1024
@@ -53,7 +54,7 @@ type Argon2Params struct {
 	Memory uint32
 	// Iterations is the number of passes over the memory.
 	Iterations uint32
-	// Parallelism is the number of threads (or lanes) used by the algorithm. Uses the runtime cpus count by default.
+	// Parallelism is the number of threads (or lanes) used by the algorithm. Defaults to the host CPU count when zero.
 	Parallelism uint8
 	// SaltLength is the length of the random salt. 16 bytes is recommended for password hashing.
 	SaltLength uint
@@ -84,7 +85,7 @@ func GenerateArgon2(password string, params Argon2Params) (string, error) {
 	// Set to number of available CPUs by default.
 	if params.Parallelism == 0 {
 		nCpus := runtime.NumCPU()
-		// Prevent overflow, even though it should hardly happen lol.
+		// Guard against overflow when narrowing to uint8.
 		if nCpus > math.MaxUint8 {
 			nCpus = math.MaxUint8
 		}
@@ -92,9 +93,6 @@ func GenerateArgon2(password string, params Argon2Params) (string, error) {
 		params.Parallelism = uint8(nCpus)
 	}
 
-	// Pass the plaintext password, salt and parameters to the argon2.IDKey
-	// function. This will generate a hash of the password using the Argon2id
-	// variant.
 	hash := argon2.IDKey(
 		[]byte(password),
 		salt,
@@ -126,7 +124,6 @@ func GenerateArgon2(password string, params Argon2Params) (string, error) {
 //
 // This is similar to bcrypt.CompareHashAndPassword but uses the more modern Argon2 algorithm.
 func CompareArgon2(password, encodedHash string) error {
-	// Extract the parameters, salt and derived key from the encoded password hash.
 	params, salt, hash, err := decodeHash(encodedHash)
 	if err != nil {
 		return fmt.Errorf("decode hash: %w", err)
@@ -142,9 +139,8 @@ func CompareArgon2(password, encodedHash string) error {
 		params.KeyLength,
 	)
 
-	// Check that the contents of the hashed passwords are identical. Note
-	// that we are using the subtle.ConstantTimeCompare() function for this
-	// to help prevent timing attacks.
+	// Compare in constant time so the response latency does not leak how much of
+	// the hash matched.
 	if subtle.ConstantTimeCompare(hash, otherHash) == 1 {
 		return nil
 	}

--- a/internal/lib/rand.go
+++ b/internal/lib/rand.go
@@ -6,8 +6,8 @@ import (
 	"math/big"
 )
 
-// URLCharList is the alphabet of URL-safe characters drawn from when generating
-// random strings.
+// URLCharList is the alphabet of URL-safe characters that NewRandomURLString draws
+// from when generating random strings.
 var URLCharList = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 
 // Alphabet length hoisted out of the generation loop.

--- a/internal/lib/rand.go
+++ b/internal/lib/rand.go
@@ -6,15 +6,16 @@ import (
 	"math/big"
 )
 
-// URLCharList is a list of URL-valid characters, for generating random strings.
+// URLCharList is the alphabet of URL-safe characters drawn from when generating
+// random strings.
 var URLCharList = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 
-// Precompute values to optimize the algorithm.
+// Alphabet length hoisted out of the generation loop.
 var (
 	urlCharListLen = int64(len(URLCharList))
 )
 
-// NewRandomURLString generates a random, url-safe text of a given length.
+// NewRandomURLString generates a random, URL-safe string of the given length.
 func NewRandomURLString(length int) (string, error) {
 	out := make([]rune, length)
 

--- a/internal/lib/resolveDependants.go
+++ b/internal/lib/resolveDependants.go
@@ -39,12 +39,7 @@ func printDepsGraph[Mod comparable](deps map[Mod]map[Mod]bool) string {
 // Algorithm: topological sort over the inheritance graph; nodes are processed
 // in order of depth (mods with no parents first), and each resolved mod's
 // inherited deps are appended in resolution order.
-//
-// Inlined from github.com/a-novel-kit/golib/deps after that package was
-// deprecated for single-consumer-in-org. See manage-versions ("Step 0 —
-// grep consumers first") for the bar; this consumer was below it.
 func ResolveDependants[Mod comparable, Deps any](mods map[Mod][]Deps, deps map[Mod][]Mod) (map[Mod][]Deps, error) {
-	// Reference: https://dnaeon.github.io/dependency-graph-resolution-algorithm-in-go/
 	// Seed every mod from `mods` into depsGraph as a leaf (no parents). This is what
 	// lets callers omit empty entries from `deps` — e.g. `deps = {mod2: [mod1]}` without
 	// an explicit `mod1: []` — and have the algorithm still find a depth-0 root to start

--- a/internal/models/mails/assets/assets.go
+++ b/internal/models/mails/assets/assets.go
@@ -1,3 +1,5 @@
+// Package assets embeds the static files the email templates need and exposes them
+// in the encoding those templates consume.
 package assets
 
 import (
@@ -8,4 +10,6 @@ import (
 //go:embed banner.png
 var banner []byte
 
+// BannerBase64 is the banner image as a base64 data URI, ready to drop into an HTML
+// image source so the email renders the banner inline without fetching a remote asset.
 var BannerBase64 = "data:image/png;base64," + base64.StdEncoding.EncodeToString(banner)

--- a/internal/models/mails/mails.go
+++ b/internal/models/mails/mails.go
@@ -1,3 +1,6 @@
+// Package mails holds the transactional email templates. Each email type is embedded
+// once per supported language and parsed at initialization into a ready-to-render
+// template set that the sending code selects by language.
 package mails
 
 import (
@@ -25,9 +28,8 @@ var (
 	registerEn string
 )
 
-// Template variable names. The mail templates expect these exact keys in the data map
-// passed to SendMail. Defined here so the three send-mail call sites (register, password
-// reset, email update) and the templates themselves stay in sync from a single source.
+// The templates read their values from a data map keyed by these names. Defining the
+// keys here keeps the sending code and the templates in sync against one source.
 const (
 	TemplateVarShortCode = "ShortCode"
 	TemplateVarTarget    = "Target"
@@ -37,18 +39,26 @@ const (
 	TemplateVarPurpose   = "_Purpose"
 )
 
+// MailTemplates groups the parsed email templates by type. Each field carries every
+// language variant as named sub-templates, chosen by language when the mail is rendered.
 type MailTemplates struct {
 	EmailUpdate   *template.Template
 	PasswordReset *template.Template
 	Register      *template.Template
 }
 
+// Mails holds the ready-to-render email templates. They are parsed once at package
+// initialization, where a malformed template panics rather than deferring the failure
+// to the moment a mail is sent.
 var Mails = MailTemplates{
 	EmailUpdate:   template.Must(template.New(config.LangEN).Parse(emailUpdateEn)),
 	PasswordReset: template.Must(template.New(config.LangEN).Parse(passwordResetEn)),
 	Register:      template.Must(template.New(config.LangEN).Parse(registerEn)),
 }
 
+// Attach the French variant to each template as an associated sub-template, so one
+// MailTemplates field can render either language. The results are discarded because only
+// the side effect of registering the parsed variant matters.
 var (
 	_ = template.Must(Mails.EmailUpdate.New(config.LangFR).Parse(emailUpdateFr))
 	_ = template.Must(Mails.PasswordReset.New(config.LangFR).Parse(passwordResetFr))

--- a/internal/models/migrations/20250208151300_short_codes_table.up.sql
+++ b/internal/models/migrations/20250208151300_short_codes_table.up.sql
@@ -1,22 +1,18 @@
 CREATE TABLE short_codes (
   id uuid PRIMARY KEY NOT NULL,
-  /* The encrypted code. Clear version of this code is sent to the target. */
+  /* The encrypted code. The plaintext version is sent to the target. */
   code text NOT NULL,
-  /* Action this short code is intended for. */
+  /* Action this code authorizes. */
   usage text NOT NULL,
-  /* Information about the target this code was issued for. */
+  /* The target this code was issued for. */
   target text NOT NULL,
-  /* Data that is required by the action requiring the short code. */
+  /* Opaque payload the code's action needs to complete. */
   data bytea,
   created_at timestamp(0) with time zone NOT NULL,
-  /* Sets an expiration date for the short code. */
   expires_at timestamp(0) with time zone NOT NULL,
-  /*
-  Use this field to expire a short code early, in case it
-  was compromised.
-  */
+  /* Soft-deletion timestamp; set to expire a code early, e.g. when compromised. */
   deleted_at timestamp(0) with time zone,
-  /* Extra information about the deprecation of the short code. */
+  /* Reason the code was deleted early. */
   deleted_comment text
 );
 

--- a/internal/models/migrations/20260510140000_short_codes_active_unique.up.sql
+++ b/internal/models/migrations/20260510140000_short_codes_active_unique.up.sql
@@ -1,13 +1,12 @@
 /*
-Close the (target, usage) race in ShortCodeInsert by enforcing at the
-database level what the application has always intended: at most one
-non-deleted short code per (target, usage) pair.
+The unique index enforces at most one non-deleted short code per (target, usage)
+pair, closing a check-then-insert race in the application's ShortCodeInsert path.
 
-Pre-cleanup soft-deletes any duplicate active rows the racy check-then-insert
-may have introduced before the constraint can be applied. The most recent
-row per (target, usage) is kept; older duplicates are marked deleted with a
-distinct comment so they're auditable. In a healthy deployment this affects
-zero rows.
+The index can only be created once existing rows satisfy it, so this step first
+soft-deletes any duplicate active rows the race may have left behind. The most
+recent row per (target, usage) is kept; older duplicates are marked deleted with a
+distinct comment so they stay auditable. In a healthy deployment this affects zero
+rows.
 */
 WITH
   ranked AS (
@@ -42,11 +41,11 @@ WHERE
 
 /*
 Postgres requires partial-index predicates to be IMMUTABLE, so the predicate
-can't include `expires_at > now()` directly. The (deleted_at IS NULL) form
-covers active conflicts; naturally-expired-but-not-yet-deleted rows are also
-in the partial index, but the dao always runs a discardExpired soft-delete
-step before either the Override=true or Override=false conflict path, so
-those stale rows never block a fresh insert.
+can't test `expires_at > now()` directly. The (deleted_at IS NULL) form covers
+active conflicts; rows that have naturally expired but aren't yet soft-deleted
+also sit in the partial index, but the DAO always runs its discardExpired
+soft-delete step before either conflict path, so those stale rows never block a
+fresh insert.
 */
 CREATE UNIQUE INDEX short_codes_active_target_usage_uniq ON short_codes (target, usage)
 WHERE

--- a/internal/models/migrations/migrations.go
+++ b/internal/models/migrations/migrations.go
@@ -1,8 +1,13 @@
+// Package migrations embeds the service's SQL schema migrations so the migration
+// runner can apply them straight from the compiled binary.
 package migrations
 
 import (
 	"embed"
 )
 
+// Migrations holds the up and down schema migration files, discovered by their
+// timestamped filenames and applied in order by the migration runner.
+//
 //go:embed *.sql
 var Migrations embed.FS

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,4 +1,3 @@
-# Created with https://editor.swagger.io/
 openapi: 3.1.0
 
 servers:
@@ -16,8 +15,8 @@ info:
 
     ## Access tokens
 
-    Most routes require an access token for simpler permission management. Thus, most call should expect at least an 
-    anonymous token, i.e. a token that grants less rights, but can be created on-the-fly without any plain credentials.
+    Most routes require an access token for simpler permission management. Thus, most calls should expect at least an
+    anonymous token, i.e. a token that grants fewer rights, but can be created on the fly without any plain credentials.
 
     Authenticated users can refresh their session using a refresh token. This token has a longer expiry date, and can
     be used to create new access tokens on-demand. There is no way to refresh a refresh token, so once it expires, the
@@ -26,8 +25,8 @@ info:
     ## Short codes
 
     For some secure operations, users can receive a short code on a secure channel: this acts as a temporary, single-use
-    password. This code is NEVER returned by the API, the user is expected to retrieve it itself then complete the
-    operation with the information it was provided with. Usually, the message will contain a link for this very purpose.
+    password. The code is never returned by the API; the user retrieves it from that channel, then completes the
+    operation with it. Usually, the message will contain a link for this very purpose.
   version: v2.4.3
   license:
     name: AGPL-3.0
@@ -41,8 +40,8 @@ paths:
       description: |
         A simple endpoint to check if the server is up and running. It always returns the same response.
 
-        Note this **DOES NOT** give information about the server dependencies. To get more information about the server
-        actual health, please use the `/healthcheck` endpoint.
+        This does not report on the server's dependencies. To assess the server's actual health, use the
+        `/healthcheck` endpoint.
       tags: [health]
       security: []
       responses:
@@ -112,8 +111,8 @@ paths:
       description: |
         Trade a user's plain credentials for a safe token it can use to authenticate against the API.
 
-        **Security note:** This endpoint returns the same 401 status for both invalid email and invalid password
-        to prevent email enumeration attacks.
+        Both an invalid email and an invalid password return the same 401 status, to avoid revealing whether an
+        email is registered.
       tags: [session]
       security: []
       requestBody:
@@ -136,7 +135,7 @@ paths:
       summary: Create a new anonymous access token.
       description: |
         Create an anonymous token to authenticate against the API without credentials.
-        Anonymous tokens bear less rights than plain authenticated users.
+        Anonymous tokens bear fewer rights than those of a plain authenticated user.
       tags: [session]
       security: []
       responses:
@@ -152,12 +151,10 @@ paths:
       operationId: credentialsExists
       summary: Check if a given email is registered in the database.
       description: |
-        Returns a success status if the email matches a registered user in the database, throws a not found (404) error
-        otherwise.
+        Returns a success status if the email matches a registered user, or a not found (404) error otherwise.
 
-        **Security note:** This endpoint intentionally reveals whether an email is registered and is restricted
-        to authenticated users with the `credentials:exist` permission. It should only be granted to trusted
-        administrative roles.
+        This endpoint deliberately reveals whether an email is registered, so it is restricted to callers holding
+        the `credentials:exist` permission and should be granted only to trusted administrative roles.
       tags: [credentials]
       security:
         - BearerAuth: ["credentials:exist"]
@@ -282,7 +279,7 @@ paths:
       operationId: passwordUpdate
       summary: Update the user password.
       description: |
-        Update the password of a user. The current password **MUST BE** provided for extra security.
+        Update the password of a user. The current password must be provided as an extra safeguard.
       tags: [credentials]
       security:
         - BearerAuth: ["credentials:password:patch"]
@@ -329,9 +326,8 @@ paths:
       operationId: roleUpdate
       summary: Update the user role.
       description: |
-        Update the role of a user. The role of the user performing the action, in addition to having the required 
-        permissions, **MUST BE** higher in the hierarchy than the initial target user role, and **CANNOT** grant 
-        privileges higher than its own.
+        Update the role of a user. Beyond holding the required permission, the caller's own role must sit higher in
+        the hierarchy than the target user's current role, and cannot grant privileges above its own.
       tags: [credentials]
       security:
         - BearerAuth: ["credentials:role:patch"]
@@ -360,8 +356,8 @@ paths:
         manages to open the link, it means the email is valid and no further validation is required. It can proceed to
         complete its account safely.
 
-        **Security note:** This endpoint always returns 202 regardless of whether the email is already registered,
-        to prevent email enumeration attacks. If the email is already registered, no email will be sent.
+        The response is always 202 whether or not the email is already registered, to avoid revealing which
+        emails have accounts. No email is sent when the address is already registered.
       tags: [shortCode]
       security:
         - BearerAuth: ["shortCode:register"]
@@ -371,9 +367,6 @@ paths:
         "202":
           description: |
             The request was accepted. If the email is not already registered, a registration link will be sent.
-
-            **Security note:** This endpoint always returns 202 regardless of whether the email is registered,
-            to prevent email enumeration attacks. If the email is already registered, no email will be sent.
         "400":
           $ref: "#/components/responses/badRequest"
         "403":
@@ -401,8 +394,8 @@ paths:
           description: |
             The request was accepted. If the email is not already registered, an email update link will be sent.
 
-            **Security note:** This endpoint always returns 202 regardless of whether the email is registered,
-            to prevent email enumeration attacks. If the email is already registered, no email will be sent.
+            The response is always 202 whether or not the email is registered, to avoid revealing which emails
+            have accounts. No email is sent when the address is already registered.
         "400":
           $ref: "#/components/responses/badRequest"
         "403":
@@ -419,8 +412,8 @@ paths:
       description: |
         Start the password reset process, by sending a link with a unique short code to the user email.
 
-        **Security note:** This endpoint always returns 202 regardless of whether the email is registered,
-        to prevent email enumeration attacks. If the email is not registered, no email will be sent.
+        The response is always 202 whether or not the email is registered, to avoid revealing which emails
+        have accounts. No email is sent when the address is not registered.
       tags: [shortCode]
       security:
         - BearerAuth: ["shortCode:password:reset"]
@@ -442,7 +435,7 @@ paths:
 components:
   responses:
     pong:
-      description: "101100001100101011001010"
+      description: The server is up and running.
       content:
         text/plain:
           schema:
@@ -588,7 +581,7 @@ components:
 
     publicCredentials:
       type: object
-      description: Exposed credentials. Do not contain obfuscated data (password, etc.).
+      description: Publicly exposed credentials, without any sensitive data such as the password.
       required: [id, email, role, createdAt, updatedAt]
       properties:
         id:
@@ -661,6 +654,7 @@ components:
 
     email:
       type: string
+      description: A user's email address.
       format: email
       maxLength: 1024
       examples: [john.doe@gmail.com]
@@ -669,27 +663,32 @@ components:
       type: string
       minLength: 4
       maxLength: 1024
-      description: User password. Must be at least 4 characters.
+      description: The user's plaintext password.
       examples: [hackthenasa]
 
     shortCode:
       type: string
+      description: |
+        A temporary, single-use code delivered to the user on a secure channel to authorize a sensitive operation.
       maxLength: 1024
       examples: [abcdef123456]
 
     limit:
       type: number
+      description: Maximum number of results to return in a single page.
       format: int
       minimum: 1
       maximum: 100
 
     offset:
       type: number
+      description: Number of leading results to skip, for pagination.
       format: int
       minimum: 0
 
     lang:
       type: string
+      description: Language for user-facing messages, as an ISO 639 code.
       format: ISO-639
       enum: [en, fr]
 

--- a/pkg/go/auth.go
+++ b/pkg/go/auth.go
@@ -72,16 +72,15 @@ func SetClaimsContext(ctx context.Context, claims *Claims) context.Context {
 }
 
 // GetClaimsContext retrieves the authenticated user's claims from the context, if any.
-// Returns (nil, nil) for unauthenticated requests on optional-auth endpoints. Returns an
-// error wrapping [middlewares.ErrUnexpectedClaims] if the value stored under the claims
-// key has the wrong type.
+// Returns (nil, nil) for unauthenticated requests on optional-auth endpoints, and an error
+// if the value stored under the claims key has an unexpected type.
 func GetClaimsContext(ctx context.Context) (*Claims, error) {
 	return middlewares.GetClaimsContext(ctx)
 }
 
 // MustGetClaimsContext retrieves the authenticated user's claims from the context, returning
-// [middlewares.ErrMissingAuth] if no claims are present. Use this on endpoints that require
-// authentication; use [GetClaimsContext] on endpoints where authentication is optional.
+// an error if no claims are present. Use this on endpoints that require authentication; use
+// [GetClaimsContext] on endpoints where authentication is optional.
 func MustGetClaimsContext(ctx context.Context) (*Claims, error) {
 	return middlewares.MustGetClaimsContext(ctx)
 }

--- a/pkg/js/rest/src/api.ts
+++ b/pkg/js/rest/src/api.ts
@@ -6,11 +6,24 @@ async function decodeRawHttpResponse<T>(response: Response): Promise<T> {
   return await response.json();
 }
 
+/** Status of a single health-check dependency reported by the `/healthcheck` endpoint. */
 export type HealthDependency = {
+  /** Whether the dependency is reachable. */
   status: "up" | "down";
+  /** Failure detail, present only when the dependency is `down`. */
   err?: string;
 };
 
+/**
+ * HTTP client for the authentication REST API.
+ *
+ * The authentication service owns user credentials, sessions, and roles. Its REST API issues
+ * and refreshes the access/refresh token pairs that authenticate every other service, manages
+ * credential records, and drives the short-code flows that confirm sensitive actions by email.
+ *
+ * The endpoint helpers in this package (`tokenCreate`, `claimsGet`, `credentialsGet`, ...) each
+ * take an instance of this client as their first argument.
+ */
 export class AuthenticationApi {
   private readonly _baseUrl: string;
 
@@ -18,20 +31,35 @@ export class AuthenticationApi {
     this._baseUrl = baseUrl;
   }
 
+  /**
+   * Sends a request to the given path and discards the response body.
+   * Throws if the server returns a non-2xx status.
+   */
   async fetchVoid(input: string, init?: RequestInit): Promise<void> {
     await fetch(`${this._baseUrl}${input}`, init).then(handleHttpResponse);
   }
 
+  /**
+   * Sends a request to the given path and deserializes the JSON response body as `T`.
+   * When a Zod validator is supplied, the body is parsed through it; otherwise it is returned
+   * as-is. Throws if the server returns a non-2xx status or the body fails validation.
+   */
   async fetch<T>(input: string, validator?: ZodType<T>, init?: RequestInit): Promise<T> {
     return await fetch(`${this._baseUrl}${input}`, init)
       .then(handleHttpResponse)
       .then(validator ? decodeHttpResponse(validator) : decodeRawHttpResponse<T>);
   }
 
+  /** Checks that the server is reachable. Throws on any non-2xx response. */
   async ping(): Promise<void> {
     await this.fetchVoid("/ping", { method: "GET" });
   }
 
+  /**
+   * Returns the health status of every service dependency, keyed by dependency name.
+   * The endpoint always responds 200; a degraded dependency shows as a `down` entry,
+   * so inspect each entry's `status` field to detect one.
+   */
   async health(): Promise<Record<string, HealthDependency>> {
     return await this.fetch("/healthcheck", undefined, { method: "GET" });
   }

--- a/pkg/js/rest/src/claims.ts
+++ b/pkg/js/rest/src/claims.ts
@@ -5,6 +5,11 @@ import { HTTP_HEADERS } from "@a-novel-kit/nodelib-browser/http";
 
 import { z } from "zod";
 
+/**
+ * Identity encoded in a session's access token: the authenticated user, their roles, and the
+ * identifier of the refresh token that issued the session. An anonymous session carries roles
+ * but no user, so every field is optional.
+ */
 export const ClaimsSchema = z.object({
   userID: z.string().optional(),
   roles: z.array(RoleSchema).optional(),
@@ -13,6 +18,7 @@ export const ClaimsSchema = z.object({
 
 export type Claims = z.infer<typeof ClaimsSchema>;
 
+/** Returns the claims carried by the given access token, as resolved by the service. */
 export async function claimsGet(api: AuthenticationApi, accessToken: string): Promise<Claims> {
   return await api.fetch("/session", ClaimsSchema, {
     headers: { ...HTTP_HEADERS.JSON, Authorization: `Bearer ${accessToken}` },

--- a/pkg/js/rest/src/credentials.ts
+++ b/pkg/js/rest/src/credentials.ts
@@ -6,6 +6,10 @@ import { HTTP_HEADERS, isHttpStatusError } from "@a-novel-kit/nodelib-browser/ht
 
 import { z } from "zod";
 
+/**
+ * An account record: its identifier, current email and role, and lifecycle timestamps. The
+ * `createdAt` and `updatedAt` fields arrive as ISO strings and are parsed into `Date` objects.
+ */
 export const CredentialsSchema = z.object({
   id: z.string(),
   email: z.string(),
@@ -16,6 +20,7 @@ export const CredentialsSchema = z.object({
 
 export type Credentials = z.infer<typeof CredentialsSchema>;
 
+/** New-account details: login email, password, and the short code emailed to confirm the address. */
 export const CredentialsCreateRequestSchema = z.object({
   email: EmailSchema,
   password: PasswordSchema,
@@ -24,18 +29,21 @@ export const CredentialsCreateRequestSchema = z.object({
 
 export type CredentialsCreateRequest = z.infer<typeof CredentialsCreateRequestSchema>;
 
+/** The email address to test for an existing account. */
 export const CredentialsExistsRequestSchema = z.object({
   email: EmailSchema,
 });
 
 export type CredentialsExistsRequest = z.infer<typeof CredentialsExistsRequestSchema>;
 
+/** The identifier of the account to fetch. */
 export const CredentialsGetRequestSchema = z.object({
   id: z.uuid(),
 });
 
 export type CredentialsGetRequest = z.infer<typeof CredentialsGetRequestSchema>;
 
+/** Pagination window and an optional role filter for listing accounts. */
 export const CredentialsListRequestSchema = z.object({
   limit: z.int().max(100).optional(),
   offset: z.int().min(0).optional(),
@@ -44,6 +52,7 @@ export const CredentialsListRequestSchema = z.object({
 
 export type CredentialsListRequest = z.infer<typeof CredentialsListRequestSchema>;
 
+/** Reset details for the forgotten-password flow: the new password, the emailed short code, and the target account. */
 export const CredentialsResetPasswordRequestSchema = z.object({
   password: PasswordSchema,
   shortCode: ShortCodeSchema,
@@ -52,6 +61,7 @@ export const CredentialsResetPasswordRequestSchema = z.object({
 
 export type CredentialsResetPasswordRequest = z.infer<typeof CredentialsResetPasswordRequestSchema>;
 
+/** The target account and the short code emailed to confirm its new address. */
 export const CredentialsUpdateEmailRequestSchema = z.object({
   userID: z.uuid(),
   shortCode: ShortCodeSchema,
@@ -59,6 +69,7 @@ export const CredentialsUpdateEmailRequestSchema = z.object({
 
 export type CredentialsUpdateEmailRequest = z.infer<typeof CredentialsUpdateEmailRequestSchema>;
 
+/** The new password, guarded by the current one to prove the caller owns the account. */
 export const CredentialsUpdatePasswordRequestSchema = z.object({
   password: PasswordSchema,
   currentPassword: PasswordSchema,
@@ -66,6 +77,7 @@ export const CredentialsUpdatePasswordRequestSchema = z.object({
 
 export type CredentialsUpdatePasswordRequest = z.infer<typeof CredentialsUpdatePasswordRequestSchema>;
 
+/** The target account and the role to grant it. */
 export const CredentialsUpdateRoleRequestSchema = z.object({
   userID: z.uuid(),
   role: RoleSchema,
@@ -73,6 +85,7 @@ export const CredentialsUpdateRoleRequestSchema = z.object({
 
 export type CredentialsUpdateRoleRequest = z.infer<typeof CredentialsUpdateRoleRequestSchema>;
 
+/** Fetches a single account by its identifier. */
 export async function credentialsGet(
   api: AuthenticationApi,
   accessToken: string,
@@ -87,6 +100,7 @@ export async function credentialsGet(
   });
 }
 
+/** Reports whether an account exists for the given email, resolving to `false` on a 404 rather than throwing. */
 export async function credentialsExists(
   api: AuthenticationApi,
   accessToken: string,
@@ -107,6 +121,7 @@ export async function credentialsExists(
     });
 }
 
+/** Lists accounts within the request's pagination window, defaulting to the first 100. */
 export async function credentialsList(
   api: AuthenticationApi,
   accessToken: string,
@@ -123,6 +138,7 @@ export async function credentialsList(
   });
 }
 
+/** Registers a new account and returns the token pair for its opening session. */
 export async function credentialsCreate(
   api: AuthenticationApi,
   accessToken: string,
@@ -135,6 +151,7 @@ export async function credentialsCreate(
   });
 }
 
+/** Applies a short-code-confirmed email change and returns the updated account. */
 export async function credentialsUpdateEmail(
   api: AuthenticationApi,
   accessToken: string,
@@ -147,6 +164,7 @@ export async function credentialsUpdateEmail(
   });
 }
 
+/** Changes the password of the authenticated account, verified by its current password, and returns the updated account. */
 export async function credentialsUpdatePassword(
   api: AuthenticationApi,
   accessToken: string,
@@ -159,6 +177,7 @@ export async function credentialsUpdatePassword(
   });
 }
 
+/** Sets a new password through the forgotten-password flow, authorized by an emailed short code, and returns the updated account. */
 export async function credentialsResetPassword(
   api: AuthenticationApi,
   accessToken: string,
@@ -171,6 +190,7 @@ export async function credentialsResetPassword(
   });
 }
 
+/** Grants a new role to the target account and returns the updated account. */
 export async function credentialsUpdateRole(
   api: AuthenticationApi,
   accessToken: string,

--- a/pkg/js/rest/src/form.ts
+++ b/pkg/js/rest/src/form.ts
@@ -2,23 +2,34 @@ import { MAX_EMAIL_LENGTH, MAX_PASSWORD_LENGTH, MAX_SHORT_CODE_LENGTH, MIN_PASSW
 
 import { z } from "zod";
 
+// Field validators shared across the request schemas in this package, so a form can be checked
+// against the same bounds the service enforces before a request is sent.
+
 export const EmailSchema = z.email().max(MAX_EMAIL_LENGTH);
 
 export const PasswordSchema = z.string().min(MIN_PASSWORD_LENGTH).max(MAX_PASSWORD_LENGTH);
 
 export const ShortCodeSchema = z.string().max(MAX_SHORT_CODE_LENGTH);
 
+/** Authorization level granted to a credential and carried by a session's claims. */
 export enum Role {
+  /** Unauthenticated session, issued without credentials. */
   Anon = "auth:anon",
+  /** Standard authenticated user. */
   User = "auth:user",
+  /** Elevated operator, able to manage other users' credentials. */
   Admin = "auth:admin",
+  /** Highest privilege, able to manage admins. */
   SuperAdmin = "auth:superadmin",
 }
 
 export const RoleSchema = z.enum([Role.Anon, Role.User, Role.Admin, Role.SuperAdmin]);
 
+/** Language used to localize the emails the service sends, such as short-code messages. */
 export enum Lang {
+  /** French. */
   Fr = "fr",
+  /** English. */
   En = "en",
 }
 

--- a/pkg/js/rest/src/shortCode.ts
+++ b/pkg/js/rest/src/shortCode.ts
@@ -5,6 +5,11 @@ import { HTTP_HEADERS } from "@a-novel-kit/nodelib-browser/http";
 
 import { z } from "zod";
 
+// A short code is a one-time secret the service emails to a user to authorize a sensitive action.
+// The request here asks the service to generate and send one; the user later submits the received
+// code back through the matching credentials endpoint to complete the action. Each request names
+// the target email and the language to send the email in.
+
 export const ShortCodeCreateEmailUpdateRequestSchema = z.object({
   email: EmailSchema,
   lang: LangSchema,
@@ -26,6 +31,7 @@ export const ShortCodeCreateRegisterRequestSchema = z.object({
 
 export type ShortCodeCreateRegisterRequest = z.infer<typeof ShortCodeCreateRegisterRequestSchema>;
 
+/** Emails a short code that authorizes changing the account's email address. */
 export async function shortCodeCreateEmailUpdate(
   api: AuthenticationApi,
   accessToken: string,
@@ -38,6 +44,7 @@ export async function shortCodeCreateEmailUpdate(
   });
 }
 
+/** Emails a short code that authorizes resetting the account's password. */
 export async function shortCodeCreatePasswordReset(
   api: AuthenticationApi,
   accessToken: string,
@@ -50,6 +57,7 @@ export async function shortCodeCreatePasswordReset(
   });
 }
 
+/** Emails a short code that authorizes registering a new account under the given address. */
 export async function shortCodeCreateRegister(
   api: AuthenticationApi,
   accessToken: string,

--- a/pkg/js/rest/src/token.ts
+++ b/pkg/js/rest/src/token.ts
@@ -5,6 +5,10 @@ import { HTTP_HEADERS } from "@a-novel-kit/nodelib-browser/http";
 
 import { z } from "zod";
 
+/**
+ * A session's token pair. The short-lived access token authenticates individual requests and
+ * carries the session claims; the longer-lived refresh token renews the pair once it expires.
+ */
 export const TokenSchema = z.object({
   accessToken: z.string(),
   refreshToken: z.string(),
@@ -12,6 +16,7 @@ export const TokenSchema = z.object({
 
 export type Token = z.infer<typeof TokenSchema>;
 
+/** Credentials to open a session: the account's email and password. */
 export const TokenCreateRequestSchema = z.object({
   email: EmailSchema,
   password: PasswordSchema,
@@ -19,6 +24,7 @@ export const TokenCreateRequestSchema = z.object({
 
 export type TokenCreateRequest = z.infer<typeof TokenCreateRequestSchema>;
 
+/** The current token pair to renew, each as its base64-encoded value. */
 export const TokenRefreshRequestSchema = z.object({
   accessToken: z.base64().max(1024),
   refreshToken: z.base64().max(1024),
@@ -26,6 +32,7 @@ export const TokenRefreshRequestSchema = z.object({
 
 export type TokenRefreshRequest = z.infer<typeof TokenRefreshRequestSchema>;
 
+/** Opens an authenticated session from an email and password, returning a fresh token pair. */
 export async function tokenCreate(api: AuthenticationApi, form: TokenCreateRequest): Promise<Token> {
   return await api.fetch("/session", TokenSchema, {
     headers: { ...HTTP_HEADERS.JSON },
@@ -34,6 +41,7 @@ export async function tokenCreate(api: AuthenticationApi, form: TokenCreateReque
   });
 }
 
+/** Opens an anonymous session, returning a token pair whose claims carry no user. */
 export async function tokenCreateAnon(api: AuthenticationApi): Promise<Token> {
   return await api.fetch("/session/anon", TokenSchema, {
     headers: { ...HTTP_HEADERS.JSON },
@@ -41,6 +49,7 @@ export async function tokenCreateAnon(api: AuthenticationApi): Promise<Token> {
   });
 }
 
+/** Exchanges an expiring token pair for a new one, preserving the session's claims. */
 export async function tokenRefresh(api: AuthenticationApi, form: TokenRefreshRequest): Promise<Token> {
   return await api.fetch("/session", TokenSchema, {
     headers: { ...HTTP_HEADERS.JSON },


### PR DESCRIPTION
## Summary

Sweeps in-code comments and the project docs (README/CONTRIBUTING) against the sharpened documentation contract: **rationale over restatement**, plain voice, comments paced as navigation. Removes copy-pasted spec text in favor of concise prose plus the authoritative link, adds missing docs on exported symbols, and corrects claims that had drifted from the code.

## Scope

Comments and documentation only — **no code changed** (verified: code tokens are identical after ignoring comments and whitespace across every `.go`/`.ts`/`.proto` file). Excluded: `.github/**` (managed by `a-novel repo update`), `builds/**` (deployment infra), generated/test files, `CODE_OF_CONDUCT`/`LICENSE`.

## Test plan

- [x] Repo formatter is a no-op after the sweep
- [x] Comment-only gate passes
- [ ] CI green