### PR TITLE
feat: migrate to jwt v2 (+ service-json-keys minor)

### DIFF
--- a/cmd/rest/main.go
+++ b/cmd/rest/main.go
@@ -59,8 +59,8 @@ func main() {
 		jsonKeysCredentials...,
 	))
 
-	serviceVerifyAccessToken := servicejsonkeys.NewClaimsVerifier[core.AccessTokenClaims](jsonKeysClient)
-	serviceVerifyRefreshToken := servicejsonkeys.NewClaimsVerifier[core.RefreshTokenClaims](jsonKeysClient)
+	serviceVerifyAccessToken := lo.Must(servicejsonkeys.NewClaimsVerifier[core.AccessTokenClaims](jsonKeysClient))
+	serviceVerifyRefreshToken := lo.Must(servicejsonkeys.NewClaimsVerifier[core.RefreshTokenClaims](jsonKeysClient))
 
 	// =================================================================================================================
 	// DAO

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ tool github.com/vektra/mockery/v3
 
 require (
 	github.com/a-novel-kit/golib v0.22.10
-	github.com/a-novel-kit/jwt v1.2.0
-	github.com/a-novel/service-json-keys/v2 v2.3.2
+	github.com/a-novel-kit/jwt/v2 v2.0.0
+	github.com/a-novel/service-json-keys/v2 v2.4.0
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/go-chi/cors v1.2.2
 	github.com/go-playground/validator/v10 v10.30.3

--- a/go.sum
+++ b/go.sum
@@ -25,10 +25,10 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.57.0 h1
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.57.0/go.mod h1:gW2WKecnAdBKF4E64jL86UXyvVcsPnNunINOq72OLMk=
 github.com/a-novel-kit/golib v0.22.10 h1:4E4QZawlF0Ex8XDHz211D0BqzJPcOW0idYGSbj/y1ek=
 github.com/a-novel-kit/golib v0.22.10/go.mod h1:+CkFcCcAuFDEHSeTt7yBCuYDQeI2APzGl8mIJuS3/+w=
-github.com/a-novel-kit/jwt v1.2.0 h1:lX+4oFi1xOIhdIdj0T5I8o37YSdfjOpDQS5x4l5llsg=
-github.com/a-novel-kit/jwt v1.2.0/go.mod h1:hWpErr7XayiUNcUkwhd5LM4u767VCGCcRvvUpC7niqc=
-github.com/a-novel/service-json-keys/v2 v2.3.2 h1:54/S7o9hRNhz/pNjAl4Z9n/cz2fphwpKzry6CmQjkXk=
-github.com/a-novel/service-json-keys/v2 v2.3.2/go.mod h1:XQ/b6H3RwgLjYtCaZeClbhD/ngDUsRfaW5tHki1BTCY=
+github.com/a-novel-kit/jwt/v2 v2.0.0 h1:N9Q351PBwjLFQm3kDxryqjx57+3Z9RpaIxaFqZ3UYQg=
+github.com/a-novel-kit/jwt/v2 v2.0.0/go.mod h1:N/cS04wkXi6GxLAiWRnxXA81tuv1mc6pqDz/f7jRjxs=
+github.com/a-novel/service-json-keys/v2 v2.4.0 h1:Y2AxCQoAD6DJqFlQdTu508Np+JZgjm4E7IaXLLcJ6IM=
+github.com/a-novel/service-json-keys/v2 v2.4.0/go.mod h1:7RZWj4EOlv6HEB4xQC8FWfdse6li/Q5NBwIaRgWaNGo=
 github.com/brunoga/deep v1.3.1 h1:bSrL6FhAZa6JlVv4vsi7Hg8SLwroDb1kgDERRVipBCo=
 github.com/brunoga/deep v1.3.1/go.mod h1:GDV6dnXqn80ezsLSZ5Wlv1PdKAWAO4L5PnKYtv2dgaI=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=

--- a/internal/core/signTokenPair.go
+++ b/internal/core/signTokenPair.go
@@ -9,8 +9,7 @@ import (
 	"github.com/a-novel/service-json-keys/v2/pkg/go"
 
 	"github.com/a-novel-kit/golib/grpcf"
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jws"
+	"github.com/a-novel-kit/jwt/v2"
 
 	"github.com/a-novel/service-authentication/v2/internal/dao"
 )
@@ -54,15 +53,13 @@ func signTokenPair(
 	// Parse the refresh token's claims without verifying the signature: we just obtained
 	// it from the trusted internal signer (json-keys) on the previous line, so the issuer
 	// is trusted by construction. We only need the JTI to embed in the access token below;
-	// the access token's signature is what binds the pair end-to-end. NewInsecureVerifier
-	// is safe here precisely because the input did not come from an external party.
-	refreshTokenRecipient := jwt.NewRecipient(jwt.RecipientConfig{
-		Plugins: []jwt.RecipientPlugin{jws.NewInsecureVerifier()},
-	})
+	// the access token's signature is what binds the pair end-to-end. DecodeUnverified is
+	// safe here precisely because the input did not come from an external party.
+	refreshTokenRecipient := jwt.NewRecipient(jwt.RecipientConfig{})
 
 	var refreshTokenClaims RefreshTokenClaims
 
-	err = refreshTokenRecipient.Consume(ctx, refreshToken.GetToken(), &refreshTokenClaims)
+	err = refreshTokenRecipient.DecodeUnverified(refreshToken.GetToken(), &refreshTokenClaims)
 	if err != nil {
 		return nil, fmt.Errorf("parse refresh token: %w", err)
 	}

--- a/internal/core/tokenRefresh.go
+++ b/internal/core/tokenRefresh.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/a-novel-kit/golib/grpcf"
 	"github.com/a-novel-kit/golib/otel"
-	"github.com/a-novel-kit/jwt/jwp"
-	"github.com/a-novel-kit/jwt/jws"
+	"github.com/a-novel-kit/jwt/v2/jwp"
+	"github.com/a-novel-kit/jwt/v2/jws"
 
 	"github.com/a-novel/service-authentication/v2/internal/dao"
 )

--- a/internal/core/tokenRefresh_test.go
+++ b/internal/core/tokenRefresh_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/a-novel/service-json-keys/v2/pkg/go"
 
 	"github.com/a-novel-kit/golib/grpcf"
-	"github.com/a-novel-kit/jwt/jwp"
-	"github.com/a-novel-kit/jwt/jws"
+	"github.com/a-novel-kit/jwt/v2/jwp"
+	"github.com/a-novel-kit/jwt/v2/jws"
 
 	"github.com/a-novel/service-authentication/v2/internal/core"
 	coremocks "github.com/a-novel/service-authentication/v2/internal/core/mocks"

--- a/internal/handlers/middlewares/rest.auth.go
+++ b/internal/handlers/middlewares/rest.auth.go
@@ -14,7 +14,7 @@ import (
 	"github.com/a-novel-kit/golib/httpf"
 	"github.com/a-novel-kit/golib/logging"
 	"github.com/a-novel-kit/golib/otel"
-	"github.com/a-novel-kit/jwt/jws"
+	"github.com/a-novel-kit/jwt/v2/jws"
 
 	"github.com/a-novel/service-authentication/v2/internal/core"
 )

--- a/internal/handlers/middlewares/rest.auth_test.go
+++ b/internal/handlers/middlewares/rest.auth_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/a-novel/service-json-keys/v2/pkg/go"
 
-	"github.com/a-novel-kit/jwt/jws"
+	"github.com/a-novel-kit/jwt/v2/jws"
 
 	"github.com/a-novel/service-authentication/v2/internal/config"
 	"github.com/a-novel/service-authentication/v2/internal/core"


### PR DESCRIPTION
## Summary

Adopts `github.com/a-novel-kit/jwt/v2 v2.0.0` and `service-json-keys v2.4.0` (the decoupled Go client). This service's own module stays `/v2` — its public API is unchanged.

- **`signTokenPair`**: reads the refresh token's JTI via `Recipient.DecodeUnverified` instead of the removed `jws.NewInsecureVerifier`. Same intent, now explicit.
- **`NewClaimsVerifier`** returns `(ClaimsVerifier, error)` after the json-keys client decouple → wrapped in `lo.Must` at the two call sites.
- `jws.ErrInvalidSignature` / `jwp.ErrInvalidClaims` sentinels unchanged (path bump only).

## Ready to merge

Pinned to the released **service-json-keys v2.4.0** (a-novel/service-json-keys#779 shipped). No longer blocked.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt` clean; mocks regenerated; builds against json-keys v2.4.0. Container-harness suites run in CI.