### PR TITLE
perf(ci): adopt gha docker build cache (workflows v1.15.6)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: go generate
         shell: bash
         run: go generate ./...
-      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.15.4
+      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.15.6
         with:
           fail_message: go generate definitions are not up-to-date, please run 'go generate ./...' and commit the changes
 
@@ -30,7 +30,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/pull-bot@v1.15.4
+      - uses: a-novel-kit/workflows/generic-actions/pull-bot@v1.15.6
         id: app_token
         with:
           client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}
@@ -53,7 +53,7 @@ jobs:
       - name: pnpm
         shell: bash
         run: pnpm generate
-      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.15.4
+      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.15.6
         with:
           fail_message: pnpm definitions are not up-to-date, please run 'pnpm generate' and commit the changes
 
@@ -63,7 +63,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.15.4
+      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.15.6
 
   lint-node:
     runs-on: ubuntu-latest
@@ -71,7 +71,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.15.4
+      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.15.6
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -107,7 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/go-actions/test-go@v1.15.4
+      - uses: a-novel-kit/workflows/go-actions/test-go@v1.15.6
         id: test
         with:
           filter_extra_patterns: " | grep -v /cmd"
@@ -201,7 +201,7 @@ jobs:
       SUPER_ADMIN_PASSWORD: admin
       MAIL_HOST: http://0.0.0.0:8025
     steps:
-      - uses: a-novel-kit/workflows/node-actions/test-node@v1.15.4
+      - uses: a-novel-kit/workflows/node-actions/test-node@v1.15.6
         id: test
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -226,11 +226,12 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         id: build
         with:
           file: builds/database.Dockerfile
           image_name: ${{ github.repository }}/database
+          cache: false
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_args: >-
             -e POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" 
@@ -266,7 +267,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.15.6
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -304,7 +305,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.15.6
         with:
           file: builds/init.Dockerfile
           image_name: ${{ github.repository }}/jobs/init
@@ -366,7 +367,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -431,7 +432,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         id: build
         with:
           file: builds/standalone.rest.Dockerfile
@@ -450,7 +451,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/build-node@v1.15.4
+      - uses: a-novel-kit/workflows/node-actions/build-node@v1.15.6
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -464,7 +465,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/go-actions/go-report-card@v1.15.4
+      - uses: a-novel-kit/workflows/go-actions/go-report-card@v1.15.6
         if: github.ref == 'refs/heads/master' && success()
 
   report-codecov:
@@ -473,7 +474,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.15.4
+      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.15.6
         with:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
           coverage_files: coverage.txt,coverage/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
       tag: ${{ steps.core.outputs.tag }}
     steps:
       - id: core
-        uses: a-novel-kit/workflows/publish-actions/release-core@v1.15.4
+        uses: a-novel-kit/workflows/publish-actions/release-core@v1.15.6
         with:
           release_type: ${{ inputs.release_type }}
           dry_run: ${{ inputs.dry_run }}
@@ -71,10 +71,11 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         with:
           file: builds/database.Dockerfile
           image_name: ${{ github.repository }}/database
+          cache: false
           version: ${{ needs.release.outputs.version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_args: >-
@@ -112,7 +113,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.15.6
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -152,7 +153,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.15.6
         with:
           file: builds/init.Dockerfile
           image_name: ${{ github.repository }}/jobs/init
@@ -216,7 +217,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -281,7 +282,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         with:
           file: builds/standalone.rest.Dockerfile
           image_name: ${{ github.repository }}/standalone-rest
@@ -303,7 +304,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: a-novel-kit/workflows/publish-actions/npm@v1.15.4
+      - uses: a-novel-kit/workflows/publish-actions/npm@v1.15.6
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}
@@ -325,7 +326,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.15.4
+      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.15.6
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Adopts the cross-run Docker build cache shipped in `a-novel-kit/workflows` v1.15.6 (keystone a-novel-kit/workflows#280):

- Bumps the `a-novel-kit/workflows` pin `v1.15.4 → v1.15.6` (adds `type=gha,mode=max` layer cache to the docker build actions).
- Passes **`cache: false`** on the stock-postgres `build-database` job (`main.yaml` + `release.yaml`) — caching its ~150MB base to GHA is a net loss and it gates `test-go` on the critical path.

Part of the **Build & CI performance** Initiative (a-novel/.github#172), Epic a-novel/.github#173 — the cache-adoption slice of #1069.

## Benchmark (this service, real CI)

Measured warm/steady-state on service-authentication:

| | baseline | warm (this change) |
| --- | --- | --- |
| build-standalone-rest *(critical path)* | 121s | **54s** (−55%) |
| build-migrations / init / rest | 94 / 105 / 120s | **34 / 56 / 77s** (−36 to −64%) |
| build-database *(cache off)* | 39s | 41s (neutral) |
| **total wall-clock** | ~5.6 min | **4.1 min (~−30%)** |

First run after merge pays a one-time cache-population cost (~+35%); every run after is the warm number above.

## Layers changed

- **CI**: `main.yaml` + `release.yaml` — workflows pin bump + `cache: false` on `build-database`.

## Breaking changes

None. Additive CI-only change; no app code, no image behaviour change.

## Test plan

- [ ] main CI green on this PR, with build-job times at the warm levels above (this run populates the cache; a second push shows the full warm win)
- [ ] release.yaml unaffected (build-database still builds correctly with cache off)