### PR TITLE
perf(builds): add BuildKit cache mounts and modernize builder shape

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,21 @@
-# Ignore test files
+# Version control and CI — never needed in builds (.git is large and was
+# previously shipped to the build daemon on every build).
+.git
+.github
+.claude
+
+# Node toolchain — large and irrelevant to Go builds.
+node_modules
+
+# Test files — excluded from production images.
 **/*_test.go
 **/*.test.go
 
-.github
+# Scripts, docs, and frontend config — not part of any server build.
+# NOTE: pkg/ is intentionally NOT ignored — this service's builder stages
+# COPY ./pkg, so it must remain in the build context.
 scripts
+*.md
 **/*.ts
 **/*.js
-node_modules
+coverage/

--- a/builds/init.Dockerfile
+++ b/builds/init.Dockerfile
@@ -3,26 +3,24 @@
 # It requires a patched database instance to run properly.
 FROM docker.io/library/golang:1.26.4-alpine AS builder
 
+ENV CGO_ENABLED=0
+
 WORKDIR /app
 
-# ======================================================================================================================
-# Copy build files.
-# ======================================================================================================================
-COPY ./go.mod ./go.mod
-COPY ./go.sum ./go.sum
-COPY "./cmd/init" "./cmd/init"
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY ./cmd/init ./cmd/init
 COPY ./internal/config ./internal/config
 COPY ./internal/dao ./internal/dao
 COPY ./internal/core ./internal/core
 COPY ./internal/models/mails ./internal/models/mails
 COPY ./internal/lib ./internal/lib
 
-RUN go mod download
-
-# ======================================================================================================================
-# Build executables.
-# ======================================================================================================================
-RUN go build -o /init cmd/init/main.go
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -ldflags="-s -w" -trimpath -o /init ./cmd/init/
 
 FROM docker.io/library/alpine:3.24.1
 

--- a/builds/migrations.Dockerfile
+++ b/builds/migrations.Dockerfile
@@ -1,23 +1,21 @@
 # This image runs a job that will apply the latest migrations to a database instance.
 FROM docker.io/library/golang:1.26.4-alpine AS builder
 
+ENV CGO_ENABLED=0
+
 WORKDIR /app
 
-# ======================================================================================================================
-# Copy build files.
-# ======================================================================================================================
-COPY ./go.mod ./go.mod
-COPY ./go.sum ./go.sum
-COPY "./cmd/migrations" "./cmd/migrations"
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY ./cmd/migrations ./cmd/migrations
 COPY ./internal/config ./internal/config
 COPY ./internal/models/migrations ./internal/models/migrations
 
-RUN go mod download
-
-# ======================================================================================================================
-# Build executables.
-# ======================================================================================================================
-RUN go build -o /migrations cmd/migrations/main.go
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -ldflags="-s -w" -trimpath -o /migrations ./cmd/migrations/
 
 FROM docker.io/library/alpine:3.24.1
 

--- a/builds/rest.Dockerfile
+++ b/builds/rest.Dockerfile
@@ -3,14 +3,21 @@
 # It requires a patched database instance to run properly.
 FROM docker.io/library/golang:1.26.4-alpine AS builder
 
+# Static binary: no libc dependency, so it runs on a bare alpine base and could
+# move to scratch/distroless later.
+ENV CGO_ENABLED=0
+
 WORKDIR /app
 
-# ======================================================================================================================
-# Copy build files.
-# ======================================================================================================================
-COPY ./go.mod ./go.mod
-COPY ./go.sum ./go.sum
-COPY "./cmd/rest" "./cmd/rest"
+# Resolve modules off go.mod/go.sum alone, before the source, so the download
+# layer survives any source-only edit. The cache mount persists the module cache
+# across builds — locally this is what turns a cold re-pull into a no-op; in CI
+# the gha layer cache covers cross-run reuse.
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY ./cmd/rest ./cmd/rest
 COPY ./internal/handlers ./internal/handlers
 COPY ./internal/dao ./internal/dao
 COPY ./internal/lib ./internal/lib
@@ -19,12 +26,13 @@ COPY ./internal/models ./internal/models
 COPY ./internal/config ./internal/config
 COPY ./pkg ./pkg
 
-RUN go mod download
-
-# ======================================================================================================================
-# Build executables.
-# ======================================================================================================================
-RUN go build -o /rest cmd/rest/main.go
+# Cache mounts persist the module + build cache across builds, so a rebuild after
+# a source change recompiles only the changed packages instead of the whole tree.
+# -ldflags="-s -w" strips the symbol table + DWARF (smaller binary); -trimpath
+# drops absolute build paths for a reproducible build.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -ldflags="-s -w" -trimpath -o /rest ./cmd/rest/
 
 FROM docker.io/library/alpine:3.24.1
 
@@ -32,17 +40,10 @@ WORKDIR /
 
 COPY --from=builder /rest /rest
 
-# ======================================================================================================================
-# Healthcheck.
-# ======================================================================================================================
-RUN apk --update add curl
-
+# Alpine ships BusyBox wget — no extra package needed for the healthcheck.
 HEALTHCHECK --interval=1s --timeout=5s --retries=10 --start-period=1s \
-  CMD curl -f http://localhost:8080/ping || exit 1
+  CMD wget -qO /dev/null http://localhost:8080/ping || exit 1
 
-# ======================================================================================================================
-# Finish setup.
-# ======================================================================================================================
 # Make sure the executable uses the default port.
 ENV REST_PORT=8080
 

--- a/builds/standalone.rest.Dockerfile
+++ b/builds/standalone.rest.Dockerfile
@@ -6,16 +6,17 @@
 # version of the base rest image, suited for local development rather than full scale production.
 FROM docker.io/library/golang:1.26.4-alpine AS builder
 
+ENV CGO_ENABLED=0
+
 WORKDIR /app
 
-# ======================================================================================================================
-# Copy build files.
-# ======================================================================================================================
-COPY ./go.mod ./go.mod
-COPY ./go.sum ./go.sum
-COPY "./cmd/rest" "./cmd/rest"
-COPY "./cmd/migrations" "./cmd/migrations"
-COPY "./cmd/init" "./cmd/init"
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY ./cmd/rest ./cmd/rest
+COPY ./cmd/migrations ./cmd/migrations
+COPY ./cmd/init ./cmd/init
 COPY ./internal/handlers ./internal/handlers
 COPY ./internal/dao ./internal/dao
 COPY ./internal/lib ./internal/lib
@@ -24,14 +25,12 @@ COPY ./internal/models ./internal/models
 COPY ./internal/config ./internal/config
 COPY ./pkg ./pkg
 
-RUN go mod download
-
-# ======================================================================================================================
-# Build executables.
-# ======================================================================================================================
-RUN go build -o /rest cmd/rest/main.go
-RUN go build -o /migrations cmd/migrations/main.go
-RUN go build -o /init cmd/init/main.go
+# One RUN so the three binaries share a single warm module + build cache.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -ldflags="-s -w" -trimpath -o /rest ./cmd/rest/ && \
+    go build -ldflags="-s -w" -trimpath -o /migrations ./cmd/migrations/ && \
+    go build -ldflags="-s -w" -trimpath -o /init ./cmd/init/
 
 FROM docker.io/library/alpine:3.24.1
 
@@ -41,17 +40,10 @@ COPY --from=builder /rest /rest
 COPY --from=builder /migrations /migrations
 COPY --from=builder /init /init
 
-# ======================================================================================================================
-# Healthcheck.
-# ======================================================================================================================
-RUN apk --update add curl
-
+# Alpine ships BusyBox wget — no extra package needed for the healthcheck.
 HEALTHCHECK --interval=1s --timeout=5s --retries=10 --start-period=1s \
-  CMD curl -f http://localhost:8080/ping || exit 1
+  CMD wget -qO /dev/null http://localhost:8080/ping || exit 1
 
-# ======================================================================================================================
-# Finish setup.
-# ======================================================================================================================
 # Make sure the executable uses the default port.
 ENV REST_PORT=8080
 


### PR DESCRIPTION
## Summary

Adds BuildKit cache mounts to the four Go builder images and ports the modernized (service-json-keys) Dockerfile shape. This is the **local-dev half** of the "cache the Docker build" root fix — the CI half (gha layer cache) shipped in a-novel-kit/workflows v1.15.6 and this composes with it.

- `--mount=type=cache` for `/go/pkg/mod` + `/root/.cache/go-build` on `rest`, `standalone.rest`, `init`, `migrations` — a rebuild reuses the previous compilation instead of building cold.
- `CGO_ENABLED=0` + `-ldflags="-s -w" -trimpath` — smaller, static, reproducible binary.
- `go.mod`/`go.sum` resolved **before** the source COPYs — the module layer survives source-only edits.
- BusyBox `wget` healthcheck — drops the `apk add curl` install (smaller image, one less layer, no network fetch).
- `.dockerignore`: stop shipping `.git` (and `coverage/`, docs) to the build daemon; **`pkg/` kept** (the builders COPY it).

Closes #1068. Part of Epic a-novel/.github#173 (Build & CI performance, a-novel/.github#172).

## Local benchmark (podman, `rest` image)

| Build | Time |
| --- | --- |
| cold (empty cache mount ≈ every rebuild today) | **54s** |
| old Dockerfile rebuild (no mount, recompiles cold) | **>70s** (cut off) |
| **warm rebuild after a code edit (cache mount)** | **12s (−78%)** |

The cache mount turns the local `a-novel test` / `build` iterate loop from a full cold compile into an incremental one. (In CI the mount starts empty each run, so the gha layer cache does the cross-run work there — the two are complementary.)

## Layers changed

- **builds**: 4 builder Dockerfiles + `.dockerignore`. No app code, no image runtime behaviour change (same binaries, same entrypoints/healthcheck semantics).

## Breaking changes

None.

## Test plan

- [ ] CI `build-rest` / `build-standalone-rest` / `build-init` / `build-migrations` build and report healthy (proves the modernized Dockerfiles work end-to-end)
- [x] Local: modernized `rest` image builds and the cache mount yields the warm-rebuild speedup above