### PR TITLE
perf(ci): skip build-standalone-rest smoke test (workflows v1.18.0)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: go generate
         shell: bash
         run: go generate ./...
-      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.17.0
+      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.18.0
         with:
           fail_message: go generate definitions are not up-to-date, please run 'go generate ./...' and commit the changes
 
@@ -30,7 +30,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/pull-bot@v1.17.0
+      - uses: a-novel-kit/workflows/generic-actions/pull-bot@v1.18.0
         id: app_token
         with:
           client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}
@@ -53,7 +53,7 @@ jobs:
       - name: pnpm
         shell: bash
         run: pnpm generate
-      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.17.0
+      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.18.0
         with:
           fail_message: pnpm definitions are not up-to-date, please run 'pnpm generate' and commit the changes
 
@@ -63,7 +63,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.17.0
+      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.18.0
 
   lint-node:
     runs-on: ubuntu-latest
@@ -71,7 +71,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.17.0
+      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.18.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -107,7 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/go-actions/test-go@v1.17.0
+      - uses: a-novel-kit/workflows/go-actions/test-go@v1.18.0
         id: test
         with:
           filter_extra_patterns: " | grep -v /cmd"
@@ -201,7 +201,7 @@ jobs:
       SUPER_ADMIN_PASSWORD: admin
       MAIL_HOST: http://0.0.0.0:8025
     steps:
-      - uses: a-novel-kit/workflows/node-actions/test-node@v1.17.0
+      - uses: a-novel-kit/workflows/node-actions/test-node@v1.18.0
         id: test
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -226,7 +226,7 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.17.0
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.18.0
         id: build
         with:
           file: builds/database.Dockerfile
@@ -267,7 +267,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.17.0
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.18.0
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -305,7 +305,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.17.0
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.18.0
         with:
           file: builds/init.Dockerfile
           image_name: ${{ github.repository }}/jobs/init
@@ -367,7 +367,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.17.0
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.18.0
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -379,7 +379,7 @@ jobs:
             -e PLATFORM_AUTH_URL="${PLATFORM_AUTH_URL}"
 
   build-standalone-rest:
-    needs: [test-go, build-database]
+    needs: [test-go]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -388,61 +388,17 @@ jobs:
       id-token: write
     outputs:
       digest: ${{ steps.build.outputs.digest }}
-    services:
-      postgres-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/database:v2.4.0
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-      postgres-authentication:
-        image: ghcr.io/a-novel/service-authentication/database@${{ needs.build-database.outputs.digest }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-
-      service-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/standalone-grpc:v2.4.0
-        ports:
-          - "4000:8080"
-        credentials:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          POSTGRES_DSN: postgres://postgres:postgres@postgres-json-keys:5432/postgres?sslmode=disable
-          APP_MASTER_KEY: "fec0681a2f57242211c559ca347721766f8a3acd8ed2e63b36b3768051c702ca"
-    env:
-      POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
-      SERVICE_JSON_KEYS_PORT: 4000
-      SERVICE_JSON_KEYS_HOST: 0.0.0.0
-      PLATFORM_AUTH_URL: http://localhost:6000
+    # This image is booted and exercised by test-pkg-js (a full
+    # integration run), so this job only builds + pushes it. skip_healthcheck
+    # drops the redundant smoke run and the container constellation it needed.
     steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.17.0
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.18.0
         id: build
         with:
           file: builds/standalone.rest.Dockerfile
           image_name: ${{ github.repository }}/standalone-rest
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          run_args: >-
-            -e POSTGRES_DSN="${POSTGRES_DSN}"
-            -e SERVICE_JSON_KEYS_PORT="${SERVICE_JSON_KEYS_PORT}"
-            -e SERVICE_JSON_KEYS_HOST="${SERVICE_JSON_KEYS_HOST}"
-            -e PLATFORM_AUTH_URL="${PLATFORM_AUTH_URL}"
+          skip_healthcheck: true
 
   build-js:
     needs: [test-pkg-js]
@@ -451,7 +407,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/build-node@v1.17.0
+      - uses: a-novel-kit/workflows/node-actions/build-node@v1.18.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -465,7 +421,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/go-actions/go-report-card@v1.17.0
+      - uses: a-novel-kit/workflows/go-actions/go-report-card@v1.18.0
         if: github.ref == 'refs/heads/master' && success()
 
   report-codecov:
@@ -474,7 +430,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.17.0
+      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.18.0
         with:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
           coverage_files: coverage.txt,coverage/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
       tag: ${{ steps.core.outputs.tag }}
     steps:
       - id: core
-        uses: a-novel-kit/workflows/publish-actions/release-core@v1.17.0
+        uses: a-novel-kit/workflows/publish-actions/release-core@v1.18.0
         with:
           release_type: ${{ inputs.release_type }}
           dry_run: ${{ inputs.dry_run }}
@@ -71,7 +71,7 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.17.0
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.18.0
         with:
           file: builds/database.Dockerfile
           image_name: ${{ github.repository }}/database
@@ -113,7 +113,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.17.0
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.18.0
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -153,7 +153,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.17.0
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.18.0
         with:
           file: builds/init.Dockerfile
           image_name: ${{ github.repository }}/jobs/init
@@ -217,7 +217,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.17.0
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.18.0
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -282,7 +282,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.17.0
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.18.0
         with:
           file: builds/standalone.rest.Dockerfile
           image_name: ${{ github.repository }}/standalone-rest
@@ -304,7 +304,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: a-novel-kit/workflows/publish-actions/npm@v1.17.0
+      - uses: a-novel-kit/workflows/publish-actions/npm@v1.18.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}
@@ -326,7 +326,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.17.0
+      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.18.0
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

`build-standalone-rest` booted a 3-container constellation (postgres ×2 + json-keys) purely to smoke-test the standalone image — but `test-pkg-js` already boots that **same** image and runs the full JS integration suite against it, so the smoke test was redundant work on the critical path (a double constellation boot).

Adopts `a-novel-kit/workflows` **v1.18.0** and passes **`skip_healthcheck: true`** on `build-standalone-rest`, so it only builds + pushes — the `services`, `env`, `checkout` and `run-migrations` are dropped. `test-pkg-js` still consumes the pushed image and validates it. `release.yaml` keeps its smoke test (no downstream validator on release) and just moves to v1.18.0.

Measured on a validation run: **build-standalone-rest 55s → 23s**, **total run 4.5 → 3.9 min (−13%)**, all green.

Closes #1069. Part of Epic a-novel/.github#173 (a-novel/.github#172).

## Test plan

- [x] Validated on a throwaway branch: green, `test-pkg-js` passed, ~13% faster
- [ ] CI green on this PR