### PR TITLE
docs(dao): describe how DAOs actually join a transaction

### DIFF
--- a/internal/dao/doc.go
+++ b/internal/dao/doc.go
@@ -1,11 +1,13 @@
 // Package dao holds the Postgres data access layer of the authentication service.
 //
 // Each request type pairs with a single DAO struct exposing one Exec
-// method, mirroring the core-layer convention. DAOs pull the active
-// transaction off the context via postgres.GetContext, so callers must run them
-// inside a postgres.RunInTx block (or otherwise install a transaction on the
-// context) before calling Exec. The core consumes DAOs; nothing outside
-// this package should issue SQL directly.
+// method, mirroring the core-layer convention. DAOs resolve their database
+// handle from the context via postgres.GetContext, and work either way: with no
+// transaction installed each statement commits on its own, and when a caller has
+// opened one they take part in it without knowing. Callers that need two writes
+// to land together open that scope in the core layer, through the injected
+// transaction.Transactor. The core consumes DAOs; nothing outside this package
+// should issue SQL directly.
 //
 // SQL statements live in sibling .sql files embedded with go:embed; constraint
 // violations are mapped to package-level sentinel errors (e.g.


### PR DESCRIPTION
## Summary

The package doc instructed callers to wrap DAO calls "inside a `postgres.RunInTx` block". That block never installed a transaction on the context, while the same paragraph correctly states DAOs resolve their handle *from* the context — so following the instruction literally produced calls running on the connection pool inside a transaction that protected nothing.

That is what four core operations did until #1118, and the doc is a fair part of why: it described a convention that could not work, in the package whose authors would read it first.

It now says what is true. DAOs work either way — with no transaction installed each statement commits on its own, and when a caller has opened one they take part without knowing — and opening that scope is a core-layer decision made through the injected `transaction.Transactor`.

## Breaking changes

None. Comment only.

## Test plan

- [x] `go build ./...` passes
- [ ] CI green

`pnpm lint:go` cannot run locally in this repository (#1120); nothing here is lintable beyond a comment.