### PR TITLE
fix(core): assert the short-code timestamps deterministically

### DIFF
--- a/internal/core/shortCodeCreate_test.go
+++ b/internal/core/shortCodeCreate_test.go
@@ -84,13 +84,15 @@ func TestShortCodeCreate(t *testing.T) {
 
 			mockDao := coremocks.NewMockShortCodeCreateDao(t)
 
-			var encryptedShortCode string
+			var (
+				encryptedShortCode string
+				stampedNow         time.Time
+				stampedExpiresAt   time.Time
+			)
 
 			if testCase.daoMock != nil {
 				mockDao.EXPECT().
 					Exec(mock.Anything, mock.MatchedBy(func(data *dao.ShortCodeInsertRequest) bool {
-						now := time.Now()
-
 						var dataMap map[string]string
 
 						err := json.Unmarshal(data.Data, &dataMap)
@@ -101,12 +103,12 @@ func TestShortCodeCreate(t *testing.T) {
 							assert.Equal(t, testCase.request.Usage, data.Usage) &&
 							assert.Equal(t, testCase.request.Target, data.Target) &&
 							assert.Equal(t, testCase.request.Data, dataMap) &&
-							assert.WithinDuration(t, now, data.Now, time.Second) &&
-							assert.WithinDuration(t, now.Add(testCase.request.TTL), data.ExpiresAt, time.Second) &&
 							assert.Equal(t, testCase.request.Override, data.Override)
 					})).
 					RunAndReturn(func(_ context.Context, data *dao.ShortCodeInsertRequest) (*dao.ShortCode, error) {
 						encryptedShortCode = data.Code
+						stampedNow = data.Now
+						stampedExpiresAt = data.ExpiresAt
 
 						return testCase.daoMock.resp, testCase.daoMock.err
 					})
@@ -114,12 +116,27 @@ func TestShortCodeCreate(t *testing.T) {
 
 			service := core.NewShortCodeCreate(mockDao, config.ShortCodesPresetDefault)
 
+			// Bracket the call rather than compare against a clock read somewhere else.
+			// The service stamps its timestamp before hashing the code with Argon2id,
+			// which is deliberately expensive, so any two reads taken either side of that
+			// differ by however long the hash took — over a second on a loaded machine.
+			// A timestamp taken during the call is between these two by construction, at
+			// any speed.
+			before := time.Now()
+
 			resp, err := service.Exec(t.Context(), testCase.request)
 			require.ErrorIs(t, err, testCase.expectErr)
+
+			after := time.Now()
 
 			if testCase.expectErr == nil {
 				require.NotNil(t, resp)
 				require.NotEmpty(t, encryptedShortCode)
+
+				assert.WithinRange(t, stampedNow, before, after)
+				// Exact, not approximate: the service reads the clock once and derives the
+				// expiry from that read, so anything else means it read it twice.
+				assert.Equal(t, stampedNow.Add(testCase.request.TTL), stampedExpiresAt)
 
 				require.Equal(t, testCase.request.Usage, resp.Usage)
 				require.Equal(t, testCase.request.Target, resp.Target)


### PR DESCRIPTION
`TestShortCodeCreate/Success` compared the timestamp the service stamped against a clock read taken inside the mock matcher, with a one-second tolerance. The service hashes the code with Argon2id between those two reads, so the gap is however long that hash took. On a loaded runner it exceeds a second and the test fails for reasons unconnected to the code under test.

Closes #1119

## The fix

Bracket the call. A timestamp taken during `Exec` lies between two reads either side of it at any speed, so the assertion holds by construction.

The expiry assertion becomes exact. The service reads the clock once and derives the expiry from that read, so exact equality also checks it did not read twice.

## What I could not reproduce

With the old assertion restored and eight cores saturated, the isolated test passed 15 times out of 15. The failure needs the suite's own conditions — full parallelism plus the database containers — which is where it appeared: once in CI at a measured 1.197s gap, twice across five local full-suite runs. Three green full-suite runs since is not proof of absence, so the argument rests on the construction.

## Why not the fix the issue proposed

Making `Now` a request field moves the clock read into handlers and changes a public type to serve a test.