### PR TITLE
docs: sweep counterfactuals the earlier pass missed

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -294,8 +294,8 @@ jobs:
             -e SERVICE_JSON_KEYS_HOST="${SERVICE_JSON_KEYS_HOST}"
             -e PLATFORM_AUTH_URL="${PLATFORM_AUTH_URL}"
 
-  # Publish the JS client from the bumped tag (ref) so it carries the new
-  # version rather than the pre-bump default branch.
+  # Publish the JS client from the bumped tag (ref): the dispatch runs on master, which is
+  # still pre-bump.
   build-js:
     needs: [release]
     if: ${{ !inputs.dry_run }}

--- a/internal/core/credentialsCreate.go
+++ b/internal/core/credentialsCreate.go
@@ -81,8 +81,7 @@ func (service *CredentialsCreate) Exec(ctx context.Context, request *Credentials
 	defer span.End()
 
 	span.SetAttributes(attribute.String("email", request.Email))
-	// The password and short code never go on the span. A redacted placeholder would
-	// still leak the input length to anyone reading traces.
+	// The password and short code never go on the span. A redaction still carries its length.
 
 	err := validate.Struct(request)
 	if err != nil {

--- a/internal/core/credentialsCreate_test.go
+++ b/internal/core/credentialsCreate_test.go
@@ -316,15 +316,10 @@ func TestCredentialsCreateRequest(t *testing.T) {
 	}
 }
 
-// TestCredentialsCreateIsAtomic proves the two writes run inside one unit of
-// work rather than merely appearing to.
+// TestCredentialsCreateIsAtomic proves the two writes run inside one unit of work.
 //
-// It fails against the code this replaced: that opened a transaction, handed the
-// callback the surrounding context, and let both writes resolve the connection
-// pool and commit on their own — so consuming the short code survived a failed
-// credentials insert, and the user could not retry with the link they were sent.
-// A transactor that refuses to open reproduces that boundary exactly: if the
-// writes are inside the scope, neither dependency is ever reached.
+// The transactor is wired to refuse to open, which reproduces the scope boundary exactly:
+// with the writes inside the scope, neither dependency is ever reached.
 func TestCredentialsCreateIsAtomic(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Follow-up to the comment sweep. The earlier pass verified itself against its own diff, so comments it chose not to rewrite were never re-checked once the bar tightened to "no counterfactuals, affirmative sentences". This is the tree-wide re-scan.

Three comments rewritten.

- **`internal/core/credentialsCreate.go`** — the same span-redaction note the earlier pass fixed in the DAO layer, missed here because it lives in core. Now matches its two siblings: the password and short code never go on the span, and a redaction still carries its length.
- **`internal/core/credentialsCreate_test.go`** — `TestCredentialsCreateIsAtomic`'s doc spent five lines on the design it replaced (a transaction that handed the callback the surrounding context, so consuming the short code survived a failed insert). Replaced with how the test works today: the transactor refuses to open, which reproduces the scope boundary exactly.
- `.github/workflows/release.yaml` — the `build-js` note now gives the reason positively: the dispatch runs on master, which is still pre-bump.

## Kept deliberately

`internal/config/doc.go`'s "depend on the typed structs declared here rather than reading os.Getenv directly" — `os.Getenv` is the path a reader would otherwise take, which is the one case the counter-example earns its line. `tokenCreateAnon.go`'s "at package load rather than per request" is a timing fact, not a rejected design.

## Breaking changes

None.

## Test plan

- [x] `gofmt -l .` clean, `go build ./...` passes
- [x] `go tool -modfile=golangci-lint.mod golangci-lint run ./...` — 0 issues
- [x] `release.yaml` parses; diff contains no non-comment lines
- [ ] CI green