### PR TITLE
fix(cmd): bound mail delivery and drain it before exit

### DIFF
--- a/cmd/rest/main.go
+++ b/cmd/rest/main.go
@@ -276,8 +276,8 @@ func main() {
 // serve runs the server until an interrupt or termination signal arrives, then stops it and drains
 // whatever detached work is still in flight.
 //
-// shutdownBudget covers the whole stop, not each step: the HTTP shutdown and the drain share it, so
-// a slow drain cannot extend a deploy past what the operator configured.
+// shutdownBudget covers the whole stop. The HTTP shutdown and the drain share it, so a deploy waits
+// no longer than the operator configured.
 func serve(httpServer *http.Server, shutdownBudget time.Duration, drains ...lib.Waiter) {
 	log.Println("Starting REST server on " + httpServer.Addr)
 
@@ -302,14 +302,14 @@ func serve(httpServer *http.Server, shutdownBudget time.Duration, drains ...lib.
 		panic(err)
 	}
 
-	// Drained after the HTTP shutdown, not before: once the server stops accepting, no new send can
-	// be spawned, so the set being waited on is closed.
+	// Drained after the HTTP shutdown, once the server has stopped accepting: the set being waited
+	// on is closed by then.
 	log.Println("Draining in-flight emails...")
 
 	err = lib.Drain(shutdownCtx, drains...)
 	if err != nil {
-		// Logged rather than fatal: the process is already stopping, and mail that did not make it
-		// is a fact to report, not a reason to fail the shutdown.
+		// Logged while the process is already stopping. Mail that missed the budget is worth
+		// reporting and the shutdown still completes.
 		log.Println("Some emails were still in flight at shutdown: " + err.Error())
 	}
 }

--- a/cmd/rest/main.go
+++ b/cmd/rest/main.go
@@ -14,6 +14,7 @@ import (
 	"os/signal"
 	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -30,6 +31,7 @@ import (
 	"github.com/a-novel/service-authentication/v2/internal/core"
 	"github.com/a-novel/service-authentication/v2/internal/dao"
 	"github.com/a-novel/service-authentication/v2/internal/handlers"
+	"github.com/a-novel/service-authentication/v2/internal/lib"
 	"github.com/a-novel/service-authentication/v2/pkg/go"
 )
 
@@ -262,6 +264,21 @@ func main() {
 		BaseContext:       func(_ net.Listener) context.Context { return ctx },
 	}
 
+	serve(
+		httpServer,
+		cfg.Rest.Timeouts.Request,
+		serviceShortCodeCreateRegister,
+		serviceShortCodeCreateEmailUpdate,
+		serviceShortCodeCreatePasswordReset,
+	)
+}
+
+// serve runs the server until an interrupt or termination signal arrives, then stops it and drains
+// whatever detached work is still in flight.
+//
+// shutdownBudget covers the whole stop, not each step: the HTTP shutdown and the drain share it, so
+// a slow drain cannot extend a deploy past what the operator configured.
+func serve(httpServer *http.Server, shutdownBudget time.Duration, drains ...lib.Waiter) {
 	log.Println("Starting REST server on " + httpServer.Addr)
 
 	go func() {
@@ -277,11 +294,22 @@ func main() {
 
 	log.Println("Shutting down REST server...")
 
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.Rest.Timeouts.Request)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownBudget)
 	defer cancel()
 
 	err := httpServer.Shutdown(shutdownCtx)
 	if err != nil {
 		panic(err)
+	}
+
+	// Drained after the HTTP shutdown, not before: once the server stops accepting, no new send can
+	// be spawned, so the set being waited on is closed.
+	log.Println("Draining in-flight emails...")
+
+	err = lib.Drain(shutdownCtx, drains...)
+	if err != nil {
+		// Logged rather than fatal: the process is already stopping, and mail that did not make it
+		// is a fact to report, not a reason to fail the shutdown.
+		log.Println("Some emails were still in flight at shutdown: " + err.Error())
 	}
 }

--- a/internal/config/app.config.default.go
+++ b/internal/config/app.config.default.go
@@ -72,7 +72,6 @@ var AppPresetDefault = App{
 		UpdateEmail:    env.PlatformAuthUpdateEmailUrl,
 		UpdatePassword: env.PlatformAuthUpdatePasswordUrl,
 		Register:       env.PlatformAuthRegisterUrl,
-		Timeout:        env.SmtpTimeout,
 	},
 
 	Smtp: lo.Ternary[smtp.Sender](env.SmtpAddr == "", smtp.NewDebugSender(nil), &smtp.ProdSender{
@@ -82,6 +81,7 @@ var AppPresetDefault = App{
 		Password:            env.SmtpSenderPassword,
 		Domain:              env.SmtpSenderDomain,
 		ForceUnencryptedTls: env.SmtpForceUnencrypted,
+		Timeout:             env.SmtpTimeout,
 	}),
 	Otel: lo.If[otel.Config](!env.Otel, &otelpresets.Disabled{}).
 		ElseIf(env.GcloudProjectId == "", &otelpresets.Local{

--- a/internal/config/smtp.go
+++ b/internal/config/smtp.go
@@ -2,9 +2,8 @@ package config
 
 // SmtpUrls configures the web-client links embedded in outgoing emails.
 //
-// The send timeout does not live here. It sat on this struct while nothing read it — the sender is
-// what has to honour a timeout, and this struct never reaches the sender. A value on the wrong type
-// looks configured, which is why the setting appeared plumbed for as long as it did.
+// The send timeout lives on the sender, which is the only thing that reaches the SMTP connection.
+// This struct is read by the short-code services for their link text and goes no further.
 type SmtpUrls struct {
 	UpdateEmail    string `json:"updateEmail"    yaml:"updateEmail"`
 	UpdatePassword string `json:"updatePassword" yaml:"updatePassword"`

--- a/internal/config/smtp.go
+++ b/internal/config/smtp.go
@@ -1,11 +1,12 @@
 package config
 
-import "time"
-
-// SmtpUrls configures the web-client links embedded in outgoing emails and the timeout for sending them.
+// SmtpUrls configures the web-client links embedded in outgoing emails.
+//
+// The send timeout does not live here. It sat on this struct while nothing read it — the sender is
+// what has to honour a timeout, and this struct never reaches the sender. A value on the wrong type
+// looks configured, which is why the setting appeared plumbed for as long as it did.
 type SmtpUrls struct {
-	UpdateEmail    string        `json:"updateEmail"    yaml:"updateEmail"`
-	UpdatePassword string        `json:"updatePassword" yaml:"updatePassword"`
-	Register       string        `json:"register"       yaml:"register"`
-	Timeout        time.Duration `json:"timeout"        yaml:"timeout"`
+	UpdateEmail    string `json:"updateEmail"    yaml:"updateEmail"`
+	UpdatePassword string `json:"updatePassword" yaml:"updatePassword"`
+	Register       string `json:"register"       yaml:"register"`
 }

--- a/internal/lib/drain.go
+++ b/internal/lib/drain.go
@@ -1,0 +1,46 @@
+package lib
+
+import (
+	"context"
+	"fmt"
+)
+
+// Waiter blocks until the work it owns has finished. The short-code services implement it over the
+// detached goroutines that deliver their emails.
+type Waiter interface {
+	Wait()
+}
+
+// Drain waits for every waiter to finish, or for ctx to expire.
+//
+// Mail delivery is detached from the request that triggered it — the handler answers 202 and the
+// send continues on its own goroutine, so a cancelled request does not cancel a half-sent email.
+// The cost is that process exit kills whatever is still in flight, and nothing reports it: the 202
+// went out long ago, the goroutine's error log sits after the call that never returned, and the
+// database holds a perfectly valid unconsumed short code. The user is told to check their inbox and
+// never receives anything.
+//
+// The bound matters as much as the wait. Each send carries its own timeout, so the drain terminates
+// on its own; the context is the second belt, so a misconfigured sender delays a deploy rather than
+// blocking it forever. Draining against an unbounded send would trade dropped mail for a hung
+// shutdown, which is the worse failure for a rolling restart.
+func Drain(ctx context.Context, waiters ...Waiter) error {
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		for _, waiter := range waiters {
+			waiter.Wait()
+		}
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		// The goroutine above outlives this return. That is deliberate: it is parked on sends that
+		// are themselves bounded, and the process is exiting.
+		return fmt.Errorf("drain in-flight work: %w", ctx.Err())
+	}
+}

--- a/internal/lib/drain.go
+++ b/internal/lib/drain.go
@@ -13,17 +13,13 @@ type Waiter interface {
 
 // Drain waits for every waiter to finish, or for ctx to expire.
 //
-// Mail delivery is detached from the request that triggered it — the handler answers 202 and the
-// send continues on its own goroutine, so a cancelled request does not cancel a half-sent email.
-// The cost is that process exit kills whatever is still in flight, and nothing reports it: the 202
-// went out long ago, the goroutine's error log sits after the call that never returned, and the
-// database holds a perfectly valid unconsumed short code. The user is told to check their inbox and
-// never receives anything.
+// Mail delivery runs on its own goroutine, detached from the request that triggered it, so a
+// cancelled request leaves a half-sent email alone. Process exit then reaches whatever is still in
+// flight, and the loss is silent: the handler answered 202 long before, and the short code sits in
+// the database intact. The user checks an inbox that stays empty.
 //
-// The bound matters as much as the wait. Each send carries its own timeout, so the drain terminates
-// on its own; the context is the second belt, so a misconfigured sender delays a deploy rather than
-// blocking it forever. Draining against an unbounded send would trade dropped mail for a hung
-// shutdown, which is the worse failure for a rolling restart.
+// The bound carries as much weight as the wait. Each send holds its own timeout, and ctx is the
+// second bound, so a sender that stops answering delays a deploy by the shutdown budget.
 func Drain(ctx context.Context, waiters ...Waiter) error {
 	done := make(chan struct{})
 
@@ -39,8 +35,8 @@ func Drain(ctx context.Context, waiters ...Waiter) error {
 	case <-done:
 		return nil
 	case <-ctx.Done():
-		// The goroutine above outlives this return. That is deliberate: it is parked on sends that
-		// are themselves bounded, and the process is exiting.
+		// The goroutine above outlives this return, parked on sends that carry their own timeouts
+		// while the process exits.
 		return fmt.Errorf("drain in-flight work: %w", ctx.Err())
 	}
 }

--- a/internal/lib/drain_test.go
+++ b/internal/lib/drain_test.go
@@ -1,0 +1,75 @@
+package lib_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/a-novel/service-authentication/v2/internal/lib"
+)
+
+// blockingWaiter is a Waiter that finishes only when released, standing in for a detached email
+// send still in flight when the process is asked to stop.
+type blockingWaiter struct {
+	release chan struct{}
+	once    sync.Once
+}
+
+func newBlockingWaiter() *blockingWaiter {
+	return &blockingWaiter{release: make(chan struct{})}
+}
+
+func (w *blockingWaiter) Wait() { <-w.release }
+
+func (w *blockingWaiter) finish() { w.once.Do(func() { close(w.release) }) }
+
+func TestDrain(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WaitsForEveryWaiter", func(t *testing.T) {
+		t.Parallel()
+
+		first, second := newBlockingWaiter(), newBlockingWaiter()
+
+		errs := make(chan error, 1)
+		go func() { errs <- lib.Drain(t.Context(), first, second) }()
+
+		select {
+		case <-errs:
+			t.Fatal("Drain returned while work was still in flight")
+		case <-time.After(50 * time.Millisecond):
+		}
+
+		first.finish()
+		second.finish()
+
+		require.NoError(t, <-errs)
+	})
+
+	t.Run("ReturnsWhenNothingIsInFlight", func(t *testing.T) {
+		t.Parallel()
+
+		require.NoError(t, lib.Drain(t.Context()))
+	})
+
+	t.Run("GivesUpOnAnExpiredBudget", func(t *testing.T) {
+		t.Parallel()
+
+		stuck := newBlockingWaiter()
+		t.Cleanup(stuck.finish)
+
+		ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+		t.Cleanup(cancel)
+
+		start := time.Now()
+		err := lib.Drain(ctx, stuck)
+
+		// A sender that never returns must delay the deploy, not block it. Without the bound this
+		// blocks forever — which is why the drain could not land before the send carried a timeout.
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Less(t, time.Since(start), 5*time.Second)
+	})
+}

--- a/internal/lib/drain_test.go
+++ b/internal/lib/drain_test.go
@@ -67,8 +67,8 @@ func TestDrain(t *testing.T) {
 		start := time.Now()
 		err := lib.Drain(ctx, stuck)
 
-		// A sender that never returns must delay the deploy, not block it. Without the bound this
-		// blocks forever — which is why the drain could not land before the send carried a timeout.
+		// A sender that never returns delays the deploy by the budget and no more, which is what
+		// lets the drain wait on sends at all.
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 		require.Less(t, time.Since(start), 5*time.Second)
 	})


### PR DESCRIPTION
Closes #1112
Closes #1111

The two land together by necessity: wiring the drain against an unbounded send trades dropped mail
for a **hung shutdown**, which is the worse failure for a rolling deploy. Consumes golib `v0.25.0`,
released for this.

## #1112 — a timeout that reached nothing

`SMTP_TIMEOUT` was parsed, given a default, documented, and assigned to `SmtpUrls.Timeout`. Nothing
read it. Every other timeout in the repo lands on `http.Server` or `middleware.Timeout`; this one
landed nowhere, so an unresponsive SMTP host held a goroutine per request forever while every request
still returned `202`.

**Moved off `SmtpUrls` rather than copied from it.** That struct configures the links embedded in
outgoing mails and never reaches the sender — a timeout sitting on it was unreachable *by
construction*, while looking configured. The location is what made the defect invisible, so leaving a
now-dead field there would preserve the trap.

The enforcement itself had to be in golib (a-novel-kit/golib#382): `net/smtp` has no cancellation, so
a service-side `context.WithTimeout` reports the failure without stopping the work.

## #1111 — a drain called only by tests

`Wait()` exists on all three short-code services, each with a doc comment promising callers could
"drain pending deliveries before shutdown". `grep` found three definitions and **three call sites, all
in `_test.go`**. Production ran `httpServer.Shutdown` and returned.

That is what made it invisible: the tests calling `Wait()` are exactly what made it look wired. And
the failure reports nothing — the `202` went out long before, the goroutine's error log sits after the
call that never returns, `defer wg.Done()` never runs, its span is never `End()`ed, and the database
holds a valid unconsumed short code. The user retries and it works, so it never becomes a ticket.

Drained **after** the HTTP shutdown, so no new send can be spawned into the set being waited on, and
sharing `shutdownCtx` so the whole stop stays inside one operator-configured budget rather than the
drain being granted a fresh one.

## Notes for review

- **`lib.Drain` rather than a helper in `cmd/`.** Nothing under `cmd/` is executed by any test lane
  (see service-template#404), so logic put there is logic that cannot be tested. `internal/lib` is
  where the repo keeps small verifiable helpers.
- **`serve()` is extracted** because `main()` crossed `maintidx` once the shutdown grew — verified
  that it passes on clean master, so this is my change pushing it over, not a pre-existing debt. The
  composition root goes back to being a wiring list.
- **A failed drain logs rather than panics.** The process is already stopping; mail that did not make
  it is a fact to report, not a reason to fail the shutdown.

## Test plan

- [x] `TestDrain/GivesUpOnAnExpiredBudget` — a waiter that never finishes returns
      `context.DeadlineExceeded` instead of blocking forever. This is the assertion that makes the
      pairing safe.
- [x] `TestDrain/WaitsForEveryWaiter` — asserts it is still blocked after 50ms with work in flight,
      then returns once released, so it cannot pass by returning early
- [x] `a-novel test --type=go -y` passes
- [x] `golangci-lint v2.12.2` reports 0 issues; `prettier --check` passes
- [x] Verified end to end that `env.SmtpTimeout` now reaches `ProdSender.Timeout`, and that
      `SmtpUrls` no longer carries a timeout field
- [ ] CI green

**Not covered automatically:** the shutdown path itself. `cmd/` has no test lane, which is the reason
the drain sat unwired for as long as it did — the extraction into `lib.Drain` is what makes the
decision testable, but that `serve()` calls it remains a read.