### PR TITLE
fix(config): bound the database connection pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Every variable is read from the process environment.
 | `REST_CORS_ALLOW_CREDENTIALS` | CORS allow-credentials flag.         | `false`          |
 | `REST_CORS_MAX_AGE`           | CORS max-age, in seconds.            | `3600`           |
 
-Database connection pool (server images). The limits are **per process**: what must stay under the database's `max_connections` is the sum across every replica plus the migration job, not one replica's number. The stock `postgres` default is 100.
+Database connection pool (server images). The limits are **per process**. The database's `max_connections` has to cover every replica plus the migration job; the stock `postgres` default is 100.
 
 | Name                      | Description                               | Default |
 | ------------------------- | ----------------------------------------- | ------- |

--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ Every variable is read from the process environment.
 | `REST_CORS_ALLOW_CREDENTIALS` | CORS allow-credentials flag.         | `false`          |
 | `REST_CORS_MAX_AGE`           | CORS max-age, in seconds.            | `3600`           |
 
+Database connection pool (server images). The limits are **per process**: what must stay under the database's `max_connections` is the sum across every replica plus the migration job, not one replica's number. The stock `postgres` default is 100.
+
+| Name                      | Description                               | Default |
+| ------------------------- | ----------------------------------------- | ------- |
+| `POSTGRES_MAX_OPEN_CONNS` | Maximum open connections to the database. | `20`    |
+| `POSTGRES_MAX_IDLE_CONNS` | Maximum connections kept open while idle. | `20`    |
+
 Logs and tracing — OpenTelemetry supports a stdout and a Google Cloud exporter (images `rest`, `jobs/init`, `standalone-rest`):
 
 | Name                | Description                                                           | Default                  |

--- a/internal/config/env/env.go
+++ b/internal/config/env/env.go
@@ -37,6 +37,16 @@ const (
 	RestMaxRequestSizeDefault    = 2 << 20 // 2 MiB
 	CorsAllowCredentialsDefault  = false
 	CorsMaxAgeDefault            = 3600
+
+	// PostgresMaxOpenConnsDefault keeps the pool well under a stock PostgreSQL
+	// max_connections of 100 once multiplied by a service's replica count, leaving
+	// room for the migration job and a psql session. Go's own default is unlimited,
+	// which turns a spike into connection refusals for everything on that database
+	// rather than queueing inside this process.
+	PostgresMaxOpenConnsDefault = 20
+	// PostgresMaxIdleConnsDefault matches the open limit so a burst does not close
+	// connections it is about to reopen.
+	PostgresMaxIdleConnsDefault = 20
 )
 
 // Default values for environment variables, if applicable.
@@ -47,7 +57,9 @@ var (
 
 // Raw values for environment variables.
 var (
-	postgresDsn = getEnv("POSTGRES_DSN")
+	postgresDsn          = getEnv("POSTGRES_DSN")
+	postgresMaxOpenConns = getEnv("POSTGRES_MAX_OPEN_CONNS")
+	postgresMaxIdleConns = getEnv("POSTGRES_MAX_IDLE_CONNS")
 
 	platformAuthUrl               = getEnv("PLATFORM_AUTH_URL")
 	platformAuthUpdateEmailUrl    = getEnv("PLATFORM_AUTH_URL_UPDATE_EMAIL")
@@ -91,6 +103,11 @@ var (
 	// Typically formatted as:
 	//	postgres://<user>:<password>@<host>:<port>/<database>
 	PostgresDsn = postgresDsn
+
+	// PostgresMaxOpenConns is the maximum number of open connections to the database.
+	PostgresMaxOpenConns = config.LoadEnv(postgresMaxOpenConns, PostgresMaxOpenConnsDefault, config.IntParser)
+	// PostgresMaxIdleConns is the maximum number of connections kept open while idle.
+	PostgresMaxIdleConns = config.LoadEnv(postgresMaxIdleConns, PostgresMaxIdleConnsDefault, config.IntParser)
 
 	// PlatformAuthUrl is the base URL of the authentication web client, prefixed onto the
 	// links inserted in emails.

--- a/internal/config/postgres.config.default.go
+++ b/internal/config/postgres.config.default.go
@@ -12,11 +12,11 @@ import (
 // DSN read from the environment.
 var PostgresPresetDefault = newPostgresPreset()
 
-// newPostgresPreset builds the connection config with its pool bounded.
+// newPostgresPreset builds the connection config with its pool bounded as it opens.
 //
-// The pool is bounded as it opens. Setting the limits on the handle afterwards
-// stops working once anything has taken a connection, because the handle is
-// cached, and past that point they apply to nothing and report nothing.
+// Setting the limits on the handle afterwards stops working once anything has
+// taken a connection, because the handle is cached; past that point they apply to
+// nothing and report nothing.
 func newPostgresPreset() *postgrespresets.Default {
 	preset := postgrespresets.NewDefault(pgdriver.WithDSN(env.PostgresDsn))
 	preset.MaxOpenConns = env.PostgresMaxOpenConns

--- a/internal/config/postgres.config.default.go
+++ b/internal/config/postgres.config.default.go
@@ -14,10 +14,9 @@ var PostgresPresetDefault = newPostgresPreset()
 
 // newPostgresPreset builds the connection config with its pool bounded.
 //
-// The limits belong here rather than on the pool the config hands out: that
-// handle is cached, so setting them afterwards only takes effect if it happens
-// before anything else asks for a connection — an order nothing enforces, and
-// missing it applies them to nothing without an error.
+// The pool is bounded as it opens. Setting the limits on the handle afterwards
+// stops working once anything has taken a connection, because the handle is
+// cached, and past that point they apply to nothing and report nothing.
 func newPostgresPreset() *postgrespresets.Default {
 	preset := postgrespresets.NewDefault(pgdriver.WithDSN(env.PostgresDsn))
 	preset.MaxOpenConns = env.PostgresMaxOpenConns

--- a/internal/config/postgres.config.default.go
+++ b/internal/config/postgres.config.default.go
@@ -10,4 +10,18 @@ import (
 
 // PostgresPresetDefault is the default Postgres connection preset, built from the
 // DSN read from the environment.
-var PostgresPresetDefault = postgrespresets.NewDefault(pgdriver.WithDSN(env.PostgresDsn))
+var PostgresPresetDefault = newPostgresPreset()
+
+// newPostgresPreset builds the connection config with its pool bounded.
+//
+// The limits belong here rather than on the pool the config hands out: that
+// handle is cached, so setting them afterwards only takes effect if it happens
+// before anything else asks for a connection — an order nothing enforces, and
+// missing it applies them to nothing without an error.
+func newPostgresPreset() *postgrespresets.Default {
+	preset := postgrespresets.NewDefault(pgdriver.WithDSN(env.PostgresDsn))
+	preset.MaxOpenConns = env.PostgresMaxOpenConns
+	preset.MaxIdleConns = env.PostgresMaxIdleConns
+
+	return preset
+}


### PR DESCRIPTION
Bounds the connection pool. `database/sql` defaults `MaxOpenConns` to 0, so enough replicas exhaust the database, and the error lands on whichever process asks next — the migration job, an operator’s `psql`.

Closes #1116

## Where the limits live

On the connection config, applied as the pool opens. Setting them on the handle afterwards stops working once anything has taken a connection, because the handle is cached; past that point they apply to nothing and report nothing.

Requires golib v0.25.1, which added the fields. `main` is untouched.

## Numbers

Per process, so the budget is `replicas × max_open + jobs < max_connections`, against a stock 100. Defaults are 20/20, both environment variables.