### PR TITLE
test(ci): run the init job, instead of only defining it

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -104,9 +104,23 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
       PLATFORM_AUTH_URL: http://localhost:7010
+      SUPER_ADMIN_EMAIL: noreply@agorastoryverse.com
+      SUPER_ADMIN_PASSWORD: admin
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
+      # CI built the init job and never ran it, so nothing exercised its wiring:
+      # the config it loads, the database context it seeds, the services it
+      # assembles. Unit tests cover the logic; only the binary covers the binary.
+      #
+      # Twice on purpose. The job ensures a super-admin exists, so it is safe to
+      # re-run, and the second run is what catches it tripping over the row the
+      # first one wrote.
+      - name: Run the init job
+        shell: bash
+        run: |
+          go run ./cmd/init
+          go run ./cmd/init
       - uses: a-novel-kit/workflows/go-actions/test-go@v1.20.2
         id: test
         with:


### PR DESCRIPTION
CI never ran `cmd/init`. Nothing exercised its wiring — the config it loads, the database context it seeds, the services it assembles. Unit tests cover the logic; only the binary covers the binary.

It now runs in the lane that already has a database and applied migrations.

Closes a-novel/service-template#404

## Twice

The job ensures a super-admin exists, so it is safe to re-run. The second invocation catches it tripping over the row the first one wrote.

Verified locally: migrations, then two consecutive runs, both reporting the super-admin created or up to date.

## Coverage this adds

`cmd/init` drives `CredentialsCreateSuperAdmin`, one of the four operations #1118 made atomic. This is the first thing to execute that path as a binary.

## Scope

A smoke test. It asserts the job boots, connects and completes. What lands in the database is the unit tests' job.