### PR TITLE
feat(config): give the shutdown its own timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Every variable is read from the process environment.
 | `REST_TIMEOUT_WRITE`          | Write timeout.                       | `30s`            |
 | `REST_TIMEOUT_IDLE`           | Idle keep-alive timeout.             | `60s`            |
 | `REST_TIMEOUT_REQUEST`        | Per-request timeout.                 | `60s`            |
+| `REST_TIMEOUT_SHUTDOWN`       | Graceful-shutdown timeout.           | `25s`            |
 | `REST_CORS_ALLOWED_ORIGINS`   | CORS allowed origins.                | `*`              |
 | `REST_CORS_ALLOWED_HEADERS`   | CORS allowed headers.                | `*`              |
 | `REST_CORS_ALLOW_CREDENTIALS` | CORS allow-credentials flag.         | `false`          |
@@ -163,6 +164,22 @@ Logs and tracing — OpenTelemetry supports a stdout and a Google Cloud exporter
 | `APP_NAME`          | Application name attached to traces and logs.                         | `service-authentication` |
 
 </details>
+
+### Shutting down cleanly
+
+On `SIGTERM` the server stops accepting, drains its open requests, then waits for the emails already
+being sent. Registration and password-reset mail goes out on its own goroutine, so a send in progress
+survives the request that triggered it and outlives the signal.
+
+Three values have to increase in that order for the wait to complete:
+
+```
+SMTP_TIMEOUT (20s)  <  REST_TIMEOUT_SHUTDOWN (25s)  <  the deployment's termination grace period
+```
+
+Docker and Podman grant 10 seconds by default, which cuts the wait short and drops whatever is still
+going out. `builds/podman-compose.yaml` raises it to 30s; a Kubernetes deployment needs
+`terminationGracePeriodSeconds` set the same way.
 
 ## Using the client packages
 

--- a/builds/podman-compose.yaml
+++ b/builds/podman-compose.yaml
@@ -88,6 +88,10 @@ services:
     build:
       context: ..
       dockerfile: ./builds/standalone.rest.Dockerfile
+    # Clears REST_TIMEOUT_SHUTDOWN (25s), which in turn clears SMTP_TIMEOUT (20s). On SIGTERM the
+    # server drains its requests and then waits on the detached email sends; the runtime's 10s
+    # default sends SIGKILL partway through, dropping whatever is still going out.
+    stop_grace_period: 30s
     ports:
       - "${REST_PORT}:8080"
     depends_on:

--- a/cmd/rest/main.go
+++ b/cmd/rest/main.go
@@ -266,7 +266,7 @@ func main() {
 
 	serve(
 		httpServer,
-		cfg.Rest.Timeouts.Request,
+		cfg.Rest.Timeouts.Shutdown,
 		serviceShortCodeCreateRegister,
 		serviceShortCodeCreateEmailUpdate,
 		serviceShortCodeCreatePasswordReset,
@@ -276,9 +276,9 @@ func main() {
 // serve runs the server until an interrupt or termination signal arrives, then stops it and drains
 // whatever detached work is still in flight.
 //
-// shutdownBudget covers the whole stop. The HTTP shutdown and the drain share it, so a deploy waits
+// shutdownTimeout bounds the whole stop. The HTTP shutdown and the drain share it, so a deploy waits
 // no longer than the operator configured.
-func serve(httpServer *http.Server, shutdownBudget time.Duration, drains ...lib.Waiter) {
+func serve(httpServer *http.Server, shutdownTimeout time.Duration, drains ...lib.Waiter) {
 	log.Println("Starting REST server on " + httpServer.Addr)
 
 	go func() {
@@ -294,7 +294,7 @@ func serve(httpServer *http.Server, shutdownBudget time.Duration, drains ...lib.
 
 	log.Println("Shutting down REST server...")
 
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownBudget)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 
 	err := httpServer.Shutdown(shutdownCtx)

--- a/internal/config/app.config.default.go
+++ b/internal/config/app.config.default.go
@@ -46,6 +46,7 @@ var AppPresetDefault = App{
 			Write:      env.RestTimeoutWrite,
 			Idle:       env.RestTimeoutIdle,
 			Request:    env.RestTimeoutRequest,
+			Shutdown:   env.RestTimeoutShutdown,
 		},
 		Cors: Cors{
 			AllowedOrigins:   env.CorsAllowedOrigins,

--- a/internal/config/app.config.go
+++ b/internal/config/app.config.go
@@ -29,6 +29,8 @@ type RestTimeouts struct {
 	Write      time.Duration `json:"write"      yaml:"write"`
 	Idle       time.Duration `json:"idle"       yaml:"idle"`
 	Request    time.Duration `json:"request"    yaml:"request"`
+	// Shutdown bounds the whole stop: the HTTP server's drain and the wait on detached work share it.
+	Shutdown time.Duration `json:"shutdown" yaml:"shutdown"`
 }
 
 // Cors configures the cross-origin resource sharing policy of the REST server.

--- a/internal/config/env/env.go
+++ b/internal/config/env/env.go
@@ -34,9 +34,13 @@ const (
 	RestTimeoutWriteDefault      = 30 * time.Second
 	RestTimeoutIdleDefault       = 60 * time.Second
 	RestTimeoutRequestDefault    = 60 * time.Second
-	RestMaxRequestSizeDefault    = 2 << 20 // 2 MiB
-	CorsAllowCredentialsDefault  = false
-	CorsMaxAgeDefault            = 3600
+	// RestTimeoutShutdownDefault clears SmtpTimeoutDefault, leaving room for a send that starts
+	// just before the signal to finish. The container runtime's stop grace period has to clear
+	// this in turn; builds/podman-compose.yaml sets one.
+	RestTimeoutShutdownDefault  = 25 * time.Second
+	RestMaxRequestSizeDefault   = 2 << 20 // 2 MiB
+	CorsAllowCredentialsDefault = false
+	CorsMaxAgeDefault           = 3600
 
 	// PostgresMaxOpenConnsDefault keeps the pool well under a stock PostgreSQL
 	// max_connections of 100 once multiplied by a service's replica count, leaving
@@ -87,6 +91,7 @@ var (
 	restTimeoutWrite      = getEnv("REST_TIMEOUT_WRITE")
 	restTimeoutIdle       = getEnv("REST_TIMEOUT_IDLE")
 	restTimeoutRequest    = getEnv("REST_TIMEOUT_REQUEST")
+	restTimeoutShutdown   = getEnv("REST_TIMEOUT_SHUTDOWN")
 	corsAllowedOrigins    = getEnv("REST_CORS_ALLOWED_ORIGINS")
 	corsAllowedHeaders    = getEnv("REST_CORS_ALLOWED_HEADERS")
 	corsAllowCredentials  = getEnv("REST_CORS_ALLOW_CREDENTIALS")
@@ -180,6 +185,7 @@ var (
 	RestTimeoutWrite      = config.LoadEnv(restTimeoutWrite, RestTimeoutWriteDefault, config.DurationParser)
 	RestTimeoutIdle       = config.LoadEnv(restTimeoutIdle, RestTimeoutIdleDefault, config.DurationParser)
 	RestTimeoutRequest    = config.LoadEnv(restTimeoutRequest, RestTimeoutRequestDefault, config.DurationParser)
+	RestTimeoutShutdown   = config.LoadEnv(restTimeoutShutdown, RestTimeoutShutdownDefault, config.DurationParser)
 	CorsAllowedOrigins    = config.LoadEnv(
 		corsAllowedOrigins, CorsAllowedOriginsDefault, config.SliceParser(config.StringParser),
 	)


### PR DESCRIPTION
Follow-up to #1140. You asked for the `shutdownBudget` rename; checking where the value came from
turned up two more things.

## The rename

`serve` takes a duration that bounds the stop, so `shutdownTimeout` says what it is.

## It came from the wrong variable

The stop was handed `cfg.Rest.Timeouts.Request` — `REST_TIMEOUT_REQUEST`, which means *how long one
request may take*. Tuning that for request behaviour moved how long a deploy waits, with nothing
connecting the two. Same shape as `SmtpUrls.Timeout` in #1140: a value sitting somewhere plausible
reads as configured.

`REST_TIMEOUT_SHUTDOWN` defaults to **25s**, above `SMTP_TIMEOUT`'s 20s, so a send that starts just
before the signal has room to finish.

## The number was fiction anyway

At 60s it described a wait no container runtime grants. **No `stop_grace_period` is set anywhere in
this repo**, so the runtime default applies, and Docker and Podman send `SIGKILL` **10 seconds** after
`SIGTERM`. The drain waits on sends carrying a 20s timeout — it could not complete under any value we
chose here.

`builds/podman-compose.yaml` now sets `stop_grace_period: 30s` on the rest service. Without that half
the config change is still fiction.

Three values have to increase in order, and the README says so under a new *Shutting down cleanly*
heading:

```
SMTP_TIMEOUT (20s)  <  REST_TIMEOUT_SHUTDOWN (25s)  <  the deployment's termination grace period
```

## For a real deployment

Kubernetes grants 30s by default, which clears 25s — but only by 5s, and only while `SMTP_TIMEOUT`
stays at 20. A deployment that raises the SMTP timeout has to raise both others. The README states
the ordering rather than the numbers for that reason.

I have not touched any Kubernetes manifest; `terminationGracePeriodSeconds` is called out in the
README as the operator's to set.

## Test plan

- [x] `a-novel test --type=go -y` passes
- [x] `golangci-lint v2.12.2` reports 0 issues, `prettier --check` passes
- [x] `REST_TIMEOUT_SHUTDOWN` reaches `serve` through the same `LoadEnv` path as its siblings
- [ ] CI green

**Not covered:** the shutdown path itself, which `cmd/` has no test lane for. The drain's own bound is
covered by `TestDrain` from #1140; that `serve` passes it the right duration is a read.

## Note

`gofmt` re-aligned the `const` block when the new entry landed, so `env.go`'s diff includes
whitespace on neighbouring lines that I did not edit.