### PR TITLE
fix(dao): order the credentials listing on a stable, immutable key

### DIFF
--- a/internal/dao/pg.credentialsList.sql
+++ b/internal/dao/pg.credentialsList.sql
@@ -1,3 +1,6 @@
+-- id breaks ties on created_at, and created_at does not mutate. Ordering on updated_at let a
+-- credential touched between two page queries move across the boundary and be skipped or repeated,
+-- and its timestamp(0) precision made same-second rows a tie the planner could order either way.
 SELECT
   id,
   email,
@@ -12,7 +15,8 @@ WHERE
     OR role IN (?2)
   )
 ORDER BY
-  updated_at DESC
+  created_at DESC,
+  id DESC
 LIMIT
   ?0
 OFFSET

--- a/internal/dao/pg.credentialsList_test.go
+++ b/internal/dao/pg.credentialsList_test.go
@@ -15,8 +15,36 @@ import (
 	"github.com/a-novel/service-authentication/v2/internal/models/migrations"
 )
 
+// The listing orders by created_at DESC, id DESC. The fixtures below deliberately put
+// created_at and updated_at in different orders, so a revert to the old updated_at sort
+// produces a different slice and fails these assertions rather than passing by
+// coincidence.
 func TestCredentialsList(t *testing.T) {
 	t.Parallel()
+
+	// created_at descends 1 > 2 > 3; updated_at ascends, so ordering on it would reverse
+	// the result.
+	cred1 := &dao.Credentials{
+		ID:        uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+		Email:     "user1@email.com",
+		Role:      "test_role_user",
+		CreatedAt: time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	cred2 := &dao.Credentials{
+		ID:        uuid.MustParse("00000000-0000-0000-0000-000000000002"),
+		Email:     "user2@email.com",
+		Role:      "test_role_admin",
+		CreatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
+	}
+	cred3 := &dao.Credentials{
+		ID:        uuid.MustParse("00000000-0000-0000-0000-000000000003"),
+		Email:     "user3@email.com",
+		Role:      "test_role_user",
+		CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC),
+	}
 
 	testCases := []struct {
 		name string
@@ -31,203 +59,34 @@ func TestCredentialsList(t *testing.T) {
 		{
 			name: "Success",
 
-			fixtures: []*dao.Credentials{
-				{
-					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000001"),
-					Email:     "user1@email.com",
-					Role:      "test_role_user",
-					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-				},
-				{
-					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000002"),
-					Email:     "user2@email.com",
-					Role:      "test_role_admin",
-					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
-				},
-				{
-					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000003"),
-					Email:     "user3@email.com",
-					Role:      "test_role_user",
-					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC),
-				},
-			},
-
-			request: &dao.CredentialsListRequest{},
-
-			expect: []*dao.Credentials{
-				{
-					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000003"),
-					Email:     "user3@email.com",
-					Role:      "test_role_user",
-					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC),
-				},
-				{
-					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000002"),
-					Email:     "user2@email.com",
-					Role:      "test_role_admin",
-					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
-				},
-				{
-					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000001"),
-					Email:     "user1@email.com",
-					Role:      "test_role_user",
-					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-				},
-			},
+			fixtures: []*dao.Credentials{cred1, cred2, cred3},
+			request:  &dao.CredentialsListRequest{},
+			expect:   []*dao.Credentials{cred1, cred2, cred3}, // created_at DESC
 		},
 		{
 			name: "Success/Limit",
 
-			fixtures: []*dao.Credentials{
-				{
-					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000001"),
-					Email:     "user1@email.com",
-					Role:      "test_role_user",
-					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-				},
-				{
-					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000002"),
-					Email:     "user2@email.com",
-					Role:      "test_role_admin",
-					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
-				},
-				{
-					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000003"),
-					Email:     "user3@email.com",
-					Role:      "test_role_user",
-					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC),
-				},
-			},
-
-			request: &dao.CredentialsListRequest{
-				Limit: 2,
-			},
-
-			expect: []*dao.Credentials{
-				{
-					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000003"),
-					Email:     "user3@email.com",
-					Role:      "test_role_user",
-					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC),
-				},
-				{
-					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000002"),
-					Email:     "user2@email.com",
-					Role:      "test_role_admin",
-					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
-				},
-			},
+			fixtures: []*dao.Credentials{cred1, cred2, cred3},
+			request:  &dao.CredentialsListRequest{Limit: 2},
+			expect:   []*dao.Credentials{cred1, cred2},
 		},
 		{
 			name: "Success/Offset",
 
-			fixtures: []*dao.Credentials{
-				{
-					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000001"),
-					Email:     "user1@email.com",
-					Role:      "test_role_user",
-					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-				},
-				{
-					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000002"),
-					Email:     "user2@email.com",
-					Role:      "test_role_admin",
-					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
-				},
-				{
-					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000003"),
-					Email:     "user3@email.com",
-					Role:      "test_role_user",
-					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC),
-				},
-			},
-
-			request: &dao.CredentialsListRequest{
-				Offset: 1,
-			},
-
-			expect: []*dao.Credentials{
-				{
-					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000002"),
-					Email:     "user2@email.com",
-					Role:      "test_role_admin",
-					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
-				},
-				{
-					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000001"),
-					Email:     "user1@email.com",
-					Role:      "test_role_user",
-					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-				},
-			},
+			fixtures: []*dao.Credentials{cred1, cred2, cred3},
+			request:  &dao.CredentialsListRequest{Limit: 2, Offset: 1},
+			expect:   []*dao.Credentials{cred2, cred3},
 		},
 		{
-			name: "Success/FilterRoles",
+			name: "Success/RoleFilter",
 
-			fixtures: []*dao.Credentials{
-				{
-					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000001"),
-					Email:     "user1@email.com",
-					Role:      "test_role_user",
-					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-				},
-				{
-					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000002"),
-					Email:     "user2@email.com",
-					Role:      "test_role_admin",
-					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
-				},
-				{
-					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000003"),
-					Email:     "user3@email.com",
-					Role:      "test_role_user",
-					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC),
-				},
-			},
-
-			request: &dao.CredentialsListRequest{
-				Roles: []string{"test_role_user"},
-			},
-
-			expect: []*dao.Credentials{
-				{
-					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000003"),
-					Email:     "user3@email.com",
-					Role:      "test_role_user",
-					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC),
-				},
-				{
-					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000001"),
-					Email:     "user1@email.com",
-					Role:      "test_role_user",
-					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-				},
-			},
+			fixtures: []*dao.Credentials{cred1, cred2, cred3},
+			request:  &dao.CredentialsListRequest{Roles: []string{"test_role_user"}},
+			expect:   []*dao.Credentials{cred1, cred3}, // admin cred2 excluded
 		},
 	}
 
-	dao := dao.NewCredentialsList()
+	listDAO := dao.NewCredentialsList()
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -244,10 +103,123 @@ func TestCredentialsList(t *testing.T) {
 					require.NoError(t, err)
 				}
 
-				credentials, err := dao.Exec(ctx, testCase.request)
+				credentials, err := listDAO.Exec(ctx, testCase.request)
 				require.ErrorIs(t, err, testCase.expectErr)
 				require.Equal(t, testCase.expect, credentials)
 			})
 		})
 	}
+}
+
+// The two ways offset pagination over updated_at lost rows, both fixed by ordering on the
+// immutable created_at with id as the tiebreaker. Each pages through the whole set in
+// two reads and asserts the union is exactly what was inserted — no row skipped, none
+// repeated.
+func TestCredentialsListPaginationIsStable(t *testing.T) {
+	t.Parallel()
+
+	listDAO := dao.NewCredentialsList()
+
+	ids := func(creds []*dao.Credentials) map[uuid.UUID]int {
+		seen := map[uuid.UUID]int{}
+		for _, c := range creds {
+			seen[c.ID]++
+		}
+
+		return seen
+	}
+
+	t.Run("same-second ties page without loss", func(t *testing.T) {
+		t.Parallel()
+
+		postgres.RunDBTest(t, configtest.PostgresPreset, migrations.Migrations, func(ctx context.Context, t *testing.T) {
+			t.Helper()
+
+			db, err := postgres.GetContext(ctx)
+			require.NoError(t, err)
+
+			// Four rows sharing one created_at — the tie timestamp(0) truncation makes
+			// common. Without the id tiebreaker the planner could order the group
+			// differently per query, so a boundary row is skipped or repeated.
+			ts := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+			fixtures := make([]*dao.Credentials, 0, 4)
+
+			for i := 1; i <= 4; i++ {
+				fixtures = append(fixtures, &dao.Credentials{
+					ID:        uuid.MustParse("00000000-0000-0000-0000-00000000000" + string(rune('0'+i))),
+					Email:     "user" + string(rune('0'+i)) + "@email.com",
+					Role:      "test_role_user",
+					CreatedAt: ts,
+					UpdatedAt: ts,
+				})
+			}
+
+			_, err = db.NewInsert().Model(&fixtures).Exec(ctx)
+			require.NoError(t, err)
+
+			page1, err := listDAO.Exec(ctx, &dao.CredentialsListRequest{Limit: 2, Offset: 0})
+			require.NoError(t, err)
+
+			page2, err := listDAO.Exec(ctx, &dao.CredentialsListRequest{Limit: 2, Offset: 2})
+			require.NoError(t, err)
+
+			seen := ids(append(append([]*dao.Credentials{}, page1...), page2...))
+			require.Len(t, seen, 4, "the two pages must union to all four rows")
+
+			for id, count := range seen {
+				require.Equal(t, 1, count, "row %s appeared %d times across the pages", id, count)
+			}
+		})
+	})
+
+	t.Run("a row touched between pages is neither skipped nor repeated", func(t *testing.T) {
+		t.Parallel()
+
+		postgres.RunDBTest(t, configtest.PostgresPreset, migrations.Migrations, func(ctx context.Context, t *testing.T) {
+			t.Helper()
+
+			db, err := postgres.GetContext(ctx)
+			require.NoError(t, err)
+
+			// Distinct created_at, so this is purely the mutation problem: ordering on
+			// updated_at would move the touched row across the page boundary.
+			fixtures := make([]*dao.Credentials, 0, 4)
+
+			for i := 1; i <= 4; i++ {
+				fixtures = append(fixtures, &dao.Credentials{
+					ID:        uuid.MustParse("00000000-0000-0000-0000-00000000000" + string(rune('0'+i))),
+					Email:     "user" + string(rune('0'+i)) + "@email.com",
+					Role:      "test_role_user",
+					CreatedAt: time.Date(2021, 1, i, 0, 0, 0, 0, time.UTC),
+					UpdatedAt: time.Date(2021, 1, i, 0, 0, 0, 0, time.UTC),
+				})
+			}
+
+			_, err = db.NewInsert().Model(&fixtures).Exec(ctx)
+			require.NoError(t, err)
+
+			page1, err := listDAO.Exec(ctx, &dao.CredentialsListRequest{Limit: 2, Offset: 0})
+			require.NoError(t, err)
+
+			// The touch the old ordering was vulnerable to: bump the oldest-created row
+			// to the newest updated_at, which would drag it to the head of an
+			// updated_at ordering and across the page boundary.
+			_, err = db.NewUpdate().
+				Model((*dao.Credentials)(nil)).
+				Set("updated_at = ?", time.Date(2021, 1, 31, 0, 0, 0, 0, time.UTC)).
+				Where("id = ?", fixtures[0].ID).
+				Exec(ctx)
+			require.NoError(t, err)
+
+			page2, err := listDAO.Exec(ctx, &dao.CredentialsListRequest{Limit: 2, Offset: 2})
+			require.NoError(t, err)
+
+			seen := ids(append(append([]*dao.Credentials{}, page1...), page2...))
+			require.Len(t, seen, 4, "the mutation must not drop a row from the union")
+
+			for id, count := range seen {
+				require.Equal(t, 1, count, "row %s appeared %d times across the pages", id, count)
+			}
+		})
+	})
 }


### PR DESCRIPTION
Closes #1113, per your "go for it". Implements the Approach's primary recommendation — `ORDER BY created_at DESC, id DESC` — which matches the sibling item-listing fix and keeps offset pagination.

## The defect, two ways

`pg.credentialsList.sql` paged over `updated_at DESC` with **no tiebreaker**. Any tenant over 100 accounts must page (the core caps `Limit` at 100), and an offset page could skip or repeat an account:

1. **Mutation (the deterministic one).** `updated_at` changes. A credential touched between the page-1 and page-2 queries — role change, password reset, login-side touch — moves in the ordering and crosses the page boundary. One row drops, another repeats, **even when every timestamp is distinct**.
2. **Ties.** `timestamp(0)` truncation makes same-second rows compare equal, and the planner may order that group differently per query.

`created_at DESC, id DESC` fixes both: `created_at` is immutable, `id` breaks the tie.

## On the open question

> Is "ordered by most recently updated" a contract admins rely on, or incidental?

I read your "go for it" as endorsing the recommended cheap fix, and treated the answer as **incidental** — "most recently updated" was never reliable (it *is* the bug), and the sibling `pg.itemList.sql` already established `created_at DESC, id DESC` as the house pattern. Keyset on `(updated_at, id)` remains the escape hatch **if** "most recently changed first" is ever made a real product contract, but that's a deliberate contract change, not a side effect of this fix. Say the word if you'd rather go straight to keyset.

## The test asserted the bug

Every fixture had a distinct, **static** `updated_at` that happened to agree with `id` order, so the assertions held for an ordering the bug also produces — they'd have passed either way.

Now the fixtures put `created_at` and `updated_at` in **opposite** orders, so all four table cases fail against `updated_at DESC`. Plus `TestCredentialsListPaginationIsStable`:

- **same-second ties** — four rows share a `created_at`; paged in two reads, union is exact.
- **a row touched between pages** — distinct `created_at`, then bump one row's `updated_at` between the two reads. This is the **deterministic reproduction**: it fails reliably against `updated_at DESC` (the touched row provably moves), where the tie case is nondeterministic (Postgres *may* reorder a tie, and often doesn't).

Red check, against the old query: the four table cases fail, and the mutation case fails with *"the mutation must not drop a row from the union"*.

## Verification

Run against a **real Postgres** — the DB caught my first fixtures reusing one email (unique constraint), which is the kind of thing a mock would have waved through. Full `internal/dao` suite green, core/handlers (mocked) unaffected, `golangci-lint` 0 issues, `go generate` idempotent.

Not doing the timestamp-column widening the issue floats: the `id` tiebreaker already handles same-second ties, and widening `timestamp(0)` → `timestamptz` is an `ALTER` on a deployed table for no additional correctness here. Worth its own migration if desired, separately.
