### PR TITLE
fix(auth): make an unknown stored role a hard error, and keep it out of the DB

### DIFF
--- a/internal/config/permissions.config.go
+++ b/internal/config/permissions.config.go
@@ -2,7 +2,15 @@ package config
 
 import (
 	_ "embed"
+	"errors"
+	"fmt"
 )
+
+// ErrUnknownRole reports a role name that the permission configuration does not
+// define. A stored role that resolves to no entry is not "a role that grants
+// nothing" — it is a role the application cannot interpret, and treating the two
+// alike denied affected accounts everything with no signal.
+var ErrUnknownRole = errors.New("unknown role")
 
 // A Role bundles the permissions granted to its holders. A role may inherit other
 // roles to accumulate their permissions, and its priority ranks it against the rest
@@ -33,4 +41,18 @@ const (
 // to its Role definition.
 type Permissions struct {
 	Roles map[string]Role `json:"roles" yaml:"roles"`
+}
+
+// Priority returns the rank of a role, and ErrUnknownRole naming it when the
+// configuration defines no such role. Callers ranking a role read from the
+// database must use this rather than indexing Roles directly: a map miss yields
+// the zero Role, priority 0 — the same rank as auth:anon — so an unknown role
+// would silently outrank nobody and be outranked by everybody.
+func (p Permissions) Priority(role string) (int, error) {
+	r, ok := p.Roles[role]
+	if !ok {
+		return 0, fmt.Errorf("%w: %q", ErrUnknownRole, role)
+	}
+
+	return r.Priority, nil
 }

--- a/internal/core/credentialsUpdateRole.go
+++ b/internal/core/credentialsUpdateRole.go
@@ -84,7 +84,12 @@ func (service *CredentialsUpdateRole) Exec(
 		return nil, otel.ReportError(span, ErrCredentialsUpdateRoleSelfUpdate)
 	}
 
-	newTargetRoleImportance := config.PermissionsConfigDefault.Roles[request.Role].Priority
+	// request.Role passed validate:"role", so it is known; the lookup cannot fail.
+	newTargetRoleImportance, err := config.PermissionsConfigDefault.Priority(request.Role)
+	if err != nil {
+		return nil, otel.ReportError(span, err)
+	}
+
 	span.SetAttributes(attribute.Int("newTargetRoleImportance", newTargetRoleImportance))
 
 	targetCredentials, err := service.daoCredentialsSelect.Exec(ctx, &dao.CredentialsSelectRequest{
@@ -105,8 +110,19 @@ func (service *CredentialsUpdateRole) Exec(
 
 	span.SetAttributes(attribute.String("currentCredentials.email", currentCredentials.Email))
 
-	targetRoleIImportance := config.PermissionsConfigDefault.Roles[targetCredentials.Role].Priority
-	currentRoleIImportance := config.PermissionsConfigDefault.Roles[currentCredentials.Role].Priority
+	// These two roles come from the database, not the request, so they carry no
+	// validation. A stored role the config no longer knows is an error here, not a
+	// silent priority 0 that would let the rank guards below compare against a rank
+	// the account does not have.
+	targetRoleIImportance, err := config.PermissionsConfigDefault.Priority(targetCredentials.Role)
+	if err != nil {
+		return nil, otel.ReportError(span, fmt.Errorf("rank target role: %w", err))
+	}
+
+	currentRoleIImportance, err := config.PermissionsConfigDefault.Priority(currentCredentials.Role)
+	if err != nil {
+		return nil, otel.ReportError(span, fmt.Errorf("rank current user role: %w", err))
+	}
 
 	span.SetAttributes(
 		attribute.Int("targetRoleImportance", targetRoleIImportance),

--- a/internal/core/credentialsUpdateRole_test.go
+++ b/internal/core/credentialsUpdateRole_test.go
@@ -345,6 +345,63 @@ func TestCredentialsUpdateRole(t *testing.T) {
 
 			expectErr: errFoo,
 		},
+		{
+			// The target's stored role is one the config no longer knows — the 'user'
+			// default. Ranking it must error, not silently take priority 0 and let the
+			// hierarchy guards compare against a rank the account does not hold.
+			name: "TargetHasUnknownStoredRole",
+
+			request: &core.CredentialsUpdateRoleRequest{
+				TargetUserID:  uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+				CurrentUserID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
+				Role:          config.RoleAdmin,
+			},
+
+			daoCredentialsSelectTargetMock: &credentialsSelectMock{
+				resp: &dao.Credentials{
+					ID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					Email: "target@email.com",
+					Role:  "user",
+				},
+			},
+
+			daoCredentialsSelectCallerMock: &credentialsSelectMock{
+				resp: &dao.Credentials{
+					ID:    uuid.MustParse("00000000-0000-0000-0000-000000000002"),
+					Email: "caller@email.com",
+					Role:  config.RoleSuperAdmin,
+				},
+			},
+
+			expectErr: config.ErrUnknownRole,
+		},
+		{
+			name: "CallerHasUnknownStoredRole",
+
+			request: &core.CredentialsUpdateRoleRequest{
+				TargetUserID:  uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+				CurrentUserID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
+				Role:          config.RoleAdmin,
+			},
+
+			daoCredentialsSelectTargetMock: &credentialsSelectMock{
+				resp: &dao.Credentials{
+					ID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					Email: "target@email.com",
+					Role:  config.RoleUser,
+				},
+			},
+
+			daoCredentialsSelectCallerMock: &credentialsSelectMock{
+				resp: &dao.Credentials{
+					ID:    uuid.MustParse("00000000-0000-0000-0000-000000000002"),
+					Email: "caller@email.com",
+					Role:  "user",
+				},
+			},
+
+			expectErr: config.ErrUnknownRole,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/dao/pg.credentialsExist_test.go
+++ b/internal/dao/pg.credentialsExist_test.go
@@ -38,7 +38,7 @@ func TestCredentialsExist(t *testing.T) {
 					Password:  "password-2-hashed",
 					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 					UpdatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
-					Role:      "user",
+					Role:      "auth:user",
 				},
 			},
 

--- a/internal/dao/pg.credentialsInsert_test.go
+++ b/internal/dao/pg.credentialsInsert_test.go
@@ -36,7 +36,7 @@ func TestCredentialsInsert(t *testing.T) {
 				Email:    "user@provider.com",
 				Password: "password-hashed",
 				Now:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-				Role:     "test_role",
+				Role:     "auth:user",
 			},
 
 			expect: &dao.Credentials{
@@ -45,7 +45,7 @@ func TestCredentialsInsert(t *testing.T) {
 				Password:  "password-hashed",
 				CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 				UpdatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-				Role:      "test_role",
+				Role:      "auth:user",
 			},
 		},
 		{
@@ -55,7 +55,7 @@ func TestCredentialsInsert(t *testing.T) {
 				ID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 				Email: "user@provider.com",
 				Now:   time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-				Role:  "test_role",
+				Role:  "auth:user",
 			},
 
 			expect: &dao.Credentials{
@@ -63,7 +63,7 @@ func TestCredentialsInsert(t *testing.T) {
 				Email:     "user@provider.com",
 				CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 				UpdatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-				Role:      "test_role",
+				Role:      "auth:user",
 			},
 		},
 		{
@@ -76,7 +76,7 @@ func TestCredentialsInsert(t *testing.T) {
 					Password:  "password-2-hashed",
 					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 					UpdatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					Role:      "test_role",
+					Role:      "auth:user",
 				},
 			},
 
@@ -85,7 +85,7 @@ func TestCredentialsInsert(t *testing.T) {
 				Email:    "user@provider.com",
 				Password: "password-hashed",
 				Now:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-				Role:     "test_role",
+				Role:     "auth:user",
 			},
 
 			expectErr: dao.ErrCredentialsInsertAlreadyExists,

--- a/internal/dao/pg.credentialsList_test.go
+++ b/internal/dao/pg.credentialsList_test.go
@@ -27,21 +27,21 @@ func TestCredentialsList(t *testing.T) {
 	cred1 := &dao.Credentials{
 		ID:        uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 		Email:     "user1@email.com",
-		Role:      "test_role_user",
+		Role:      "auth:user",
 		CreatedAt: time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC),
 		UpdatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 	}
 	cred2 := &dao.Credentials{
 		ID:        uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 		Email:     "user2@email.com",
-		Role:      "test_role_admin",
+		Role:      "auth:admin",
 		CreatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
 		UpdatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
 	}
 	cred3 := &dao.Credentials{
 		ID:        uuid.MustParse("00000000-0000-0000-0000-000000000003"),
 		Email:     "user3@email.com",
-		Role:      "test_role_user",
+		Role:      "auth:user",
 		CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 		UpdatedAt: time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC),
 	}
@@ -81,7 +81,7 @@ func TestCredentialsList(t *testing.T) {
 			name: "Success/RoleFilter",
 
 			fixtures: []*dao.Credentials{cred1, cred2, cred3},
-			request:  &dao.CredentialsListRequest{Roles: []string{"test_role_user"}},
+			request:  &dao.CredentialsListRequest{Roles: []string{"auth:user"}},
 			expect:   []*dao.Credentials{cred1, cred3}, // admin cred2 excluded
 		},
 	}
@@ -148,7 +148,7 @@ func TestCredentialsListPaginationIsStable(t *testing.T) {
 				fixtures = append(fixtures, &dao.Credentials{
 					ID:        uuid.MustParse("00000000-0000-0000-0000-00000000000" + string(rune('0'+i))),
 					Email:     "user" + string(rune('0'+i)) + "@email.com",
-					Role:      "test_role_user",
+					Role:      "auth:user",
 					CreatedAt: ts,
 					UpdatedAt: ts,
 				})
@@ -189,7 +189,7 @@ func TestCredentialsListPaginationIsStable(t *testing.T) {
 				fixtures = append(fixtures, &dao.Credentials{
 					ID:        uuid.MustParse("00000000-0000-0000-0000-00000000000" + string(rune('0'+i))),
 					Email:     "user" + string(rune('0'+i)) + "@email.com",
-					Role:      "test_role_user",
+					Role:      "auth:user",
 					CreatedAt: time.Date(2021, 1, i, 0, 0, 0, 0, time.UTC),
 					UpdatedAt: time.Date(2021, 1, i, 0, 0, 0, 0, time.UTC),
 				})

--- a/internal/dao/pg.credentialsRoleConstraint_test.go
+++ b/internal/dao/pg.credentialsRoleConstraint_test.go
@@ -1,0 +1,69 @@
+package dao_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/a-novel-kit/golib/postgres"
+
+	"github.com/a-novel/service-authentication/v2/internal/config/configtest"
+	"github.com/a-novel/service-authentication/v2/internal/dao"
+	"github.com/a-novel/service-authentication/v2/internal/models/migrations"
+)
+
+// The schema now refuses a role the application does not know, and defaults new rows to a role it
+// does — the two halves of the fix that kept a bad role out of the database in the first place.
+func TestCredentialsRoleSchema(t *testing.T) {
+	t.Parallel()
+
+	t.Run("the check constraint rejects an unknown role", func(t *testing.T) {
+		t.Parallel()
+
+		postgres.RunDBTest(t, configtest.PostgresPreset, migrations.Migrations, func(ctx context.Context, t *testing.T) {
+			t.Helper()
+
+			db, err := postgres.GetContext(ctx)
+			require.NoError(t, err)
+
+			// 'user' is exactly the value the old default produced; the constraint must
+			// refuse it now.
+			_, err = db.NewInsert().Model(&dao.Credentials{
+				ID:        uuid.New(),
+				Email:     "bad-role@email.com",
+				Role:      "user",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			}).Exec(ctx)
+			require.Error(t, err, "the database must reject a role the application does not define")
+		})
+	})
+
+	t.Run("a new row without a role defaults to auth:user", func(t *testing.T) {
+		t.Parallel()
+
+		postgres.RunDBTest(t, configtest.PostgresPreset, migrations.Migrations, func(ctx context.Context, t *testing.T) {
+			t.Helper()
+
+			db, err := postgres.GetContext(ctx)
+			require.NoError(t, err)
+
+			id := uuid.New()
+
+			// Insert without naming a role, so the column default applies.
+			_, err = db.NewRaw(
+				"INSERT INTO credentials (id, email, password, created_at, updated_at) VALUES (?, ?, ?, now(), now())",
+				id, "defaulted@email.com", "hash",
+			).Exec(ctx)
+			require.NoError(t, err)
+
+			var role string
+
+			require.NoError(t, db.NewRaw("SELECT role FROM credentials WHERE id = ?", id).Scan(ctx, &role))
+			require.Equal(t, "auth:user", role, "the default must be a role the application knows")
+		})
+	})
+}

--- a/internal/dao/pg.credentialsSelectByEmail_test.go
+++ b/internal/dao/pg.credentialsSelectByEmail_test.go
@@ -38,7 +38,7 @@ func TestCredentialsSelectByEmail(t *testing.T) {
 					Password:  "password-2-hashed",
 					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 					UpdatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
-					Role:      "test_role",
+					Role:      "auth:user",
 				},
 			},
 
@@ -52,7 +52,7 @@ func TestCredentialsSelectByEmail(t *testing.T) {
 				Password:  "password-2-hashed",
 				CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 				UpdatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
-				Role:      "test_role",
+				Role:      "auth:user",
 			},
 		},
 		{

--- a/internal/dao/pg.credentialsSelect_test.go
+++ b/internal/dao/pg.credentialsSelect_test.go
@@ -38,7 +38,7 @@ func TestCredentialsSelect(t *testing.T) {
 					Password:  "password-2-hashed",
 					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 					UpdatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
-					Role:      "test_role",
+					Role:      "auth:user",
 				},
 			},
 
@@ -52,7 +52,7 @@ func TestCredentialsSelect(t *testing.T) {
 				Password:  "password-2-hashed",
 				CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 				UpdatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
-				Role:      "test_role",
+				Role:      "auth:user",
 			},
 		},
 		{

--- a/internal/dao/pg.credentialsUpdateEmail_test.go
+++ b/internal/dao/pg.credentialsUpdateEmail_test.go
@@ -38,7 +38,7 @@ func TestCredentialsUpdateEmail(t *testing.T) {
 					Password:  "password-2-hashed",
 					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 					UpdatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					Role:      "test_role_user",
+					Role:      "auth:user",
 				},
 			},
 
@@ -54,7 +54,7 @@ func TestCredentialsUpdateEmail(t *testing.T) {
 				Password:  "password-2-hashed",
 				CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 				UpdatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
-				Role:      "test_role_user",
+				Role:      "auth:user",
 			},
 		},
 		{
@@ -78,7 +78,7 @@ func TestCredentialsUpdateEmail(t *testing.T) {
 					Password:  "password-2-hashed",
 					CreatedAt: time.Date(2021, 2, 1, 0, 0, 0, 0, time.UTC),
 					UpdatedAt: time.Date(2021, 2, 1, 0, 0, 0, 0, time.UTC),
-					Role:      "test_role_user",
+					Role:      "auth:user",
 				},
 				{
 					ID:        uuid.MustParse("00000000-0000-0000-0000-000000000002"),
@@ -86,7 +86,7 @@ func TestCredentialsUpdateEmail(t *testing.T) {
 					Password:  "password-2-hashed",
 					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 					UpdatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					Role:      "test_role_user",
+					Role:      "auth:user",
 				},
 			},
 

--- a/internal/dao/pg.credentialsUpdatePassword_test.go
+++ b/internal/dao/pg.credentialsUpdatePassword_test.go
@@ -38,7 +38,7 @@ func TestCredentialsUpdatePassword(t *testing.T) {
 					Password:  "password-2-hashed",
 					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 					UpdatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					Role:      "test_role",
+					Role:      "auth:user",
 				},
 			},
 
@@ -54,7 +54,7 @@ func TestCredentialsUpdatePassword(t *testing.T) {
 				Password:  "new-password-hashed",
 				CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 				UpdatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
-				Role:      "test_role",
+				Role:      "auth:user",
 			},
 		},
 		{
@@ -67,7 +67,7 @@ func TestCredentialsUpdatePassword(t *testing.T) {
 					Password:  "password-2-hashed",
 					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 					UpdatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					Role:      "test_role",
+					Role:      "auth:user",
 				},
 			},
 
@@ -81,7 +81,7 @@ func TestCredentialsUpdatePassword(t *testing.T) {
 				Email:     "user@provider.com",
 				CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 				UpdatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
-				Role:      "test_role",
+				Role:      "auth:user",
 			},
 		},
 		{
@@ -93,7 +93,7 @@ func TestCredentialsUpdatePassword(t *testing.T) {
 					Email:     "user@provider.com",
 					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 					UpdatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					Role:      "test_role",
+					Role:      "auth:user",
 				},
 			},
 
@@ -109,7 +109,7 @@ func TestCredentialsUpdatePassword(t *testing.T) {
 				Password:  "new-password-hashed",
 				CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 				UpdatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
-				Role:      "test_role",
+				Role:      "auth:user",
 			},
 		},
 		{

--- a/internal/dao/pg.credentialsUpdateRole_test.go
+++ b/internal/dao/pg.credentialsUpdateRole_test.go
@@ -38,13 +38,13 @@ func TestCredentialsUpdateRole(t *testing.T) {
 					Password:  "password-2-hashed",
 					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 					UpdatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					Role:      "test_role_user",
+					Role:      "auth:user",
 				},
 			},
 
 			request: &dao.CredentialsUpdateRoleRequest{
 				ID:   uuid.MustParse("00000000-0000-0000-0000-000000000002"),
-				Role: "test_role_admin",
+				Role: "auth:admin",
 				Now:  time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
 			},
 
@@ -54,7 +54,7 @@ func TestCredentialsUpdateRole(t *testing.T) {
 				Password:  "password-2-hashed",
 				CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 				UpdatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
-				Role:      "test_role_admin",
+				Role:      "auth:admin",
 			},
 		},
 		{
@@ -62,7 +62,7 @@ func TestCredentialsUpdateRole(t *testing.T) {
 
 			request: &dao.CredentialsUpdateRoleRequest{
 				ID:   uuid.MustParse("00000000-0000-0000-0000-000000000002"),
-				Role: "test_role_admin",
+				Role: "auth:admin",
 				Now:  time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
 			},
 

--- a/internal/handlers/middlewares/rest.auth.go
+++ b/internal/handlers/middlewares/rest.auth.go
@@ -16,6 +16,7 @@ import (
 	"github.com/a-novel-kit/golib/otel"
 	"github.com/a-novel-kit/jwt/v2/jws"
 
+	"github.com/a-novel/service-authentication/v2/internal/config"
 	"github.com/a-novel/service-authentication/v2/internal/core"
 )
 
@@ -131,7 +132,22 @@ func (middleware *Auth) Middleware(requiredPermissions []string) func(http.Handl
 				var allowed bool
 
 				for _, role := range claims.Roles {
-					if lo.ContainsBy(middleware.permissionsByRole[role], func(item string) bool {
+					permissions, known := middleware.permissionsByRole[role]
+					if !known {
+						// The token carries a role the config does not define. It was
+						// signed by this system, so this is a data or config integrity
+						// fault, not a caller error — fail it loudly and named rather
+						// than as a permission denial byte-identical to a legitimate one.
+						httpf.HandleError(
+							ctx, middleware.logger, w, span,
+							httpf.ErrMap{nil: http.StatusInternalServerError},
+							fmt.Errorf("%w: %q in token", config.ErrUnknownRole, role),
+						)
+
+						return
+					}
+
+					if lo.ContainsBy(permissions, func(item string) bool {
 						return grantedPermissions[item]
 					}) {
 						allowed = true

--- a/internal/handlers/middlewares/rest.auth_test.go
+++ b/internal/handlers/middlewares/rest.auth_test.go
@@ -198,6 +198,29 @@ func TestAuth(t *testing.T) {
 			expectStatus: http.StatusForbidden,
 		},
 		{
+			// A token role the config does not define is an integrity fault, not a
+			// permission denial: it returns 500, distinct from the 403 above, so it is
+			// not lost among legitimate denials. This is the shape the 'user' default
+			// produced.
+			name: "Error/UnknownRole",
+
+			authHeader: "Bearer token",
+
+			permissions: []string{"write"},
+			permissionsByRole: map[string][]string{
+				"role1": {"read", "write"},
+			},
+			verifyClaimsMock: &verifyClaimsMock{
+				reqToken: "token",
+				resp: &core.AccessTokenClaims{
+					UserID: lo.ToPtr(uuid.MustParse("00000000-0000-0000-0000-000000000001")),
+					Roles:  []string{"ghost"},
+				},
+			},
+
+			expectStatus: http.StatusInternalServerError,
+		},
+		{
 			name: "Error/InvalidSignature",
 
 			authHeader: "Bearer token",

--- a/internal/models/migrations/20260723140000_fix_credentials_role_default.down.sql
+++ b/internal/models/migrations/20260723140000_fix_credentials_role_default.down.sql
@@ -1,0 +1,8 @@
+-- The 'user' -> 'auth:user' backfill is not reversed: which auth:user rows were once 'user' is not
+-- recoverable, and 'user' is the broken value this migration exists to remove.
+ALTER TABLE credentials
+DROP CONSTRAINT IF EXISTS credentials_role_check;
+
+ALTER TABLE credentials
+ALTER COLUMN role
+SET DEFAULT 'user';

--- a/internal/models/migrations/20260723140000_fix_credentials_role_default.up.sql
+++ b/internal/models/migrations/20260723140000_fix_credentials_role_default.up.sql
@@ -1,0 +1,28 @@
+-- The role column defaulted to 'user', which is not a role the application defines — every
+-- configured role is auth:*. Rows created under that default resolve to no permissions and rank
+-- priority 0, denying those accounts everything with no signal.
+-- Point the default at the intended role for a new authenticated account.
+ALTER TABLE credentials
+ALTER COLUMN role
+SET DEFAULT 'auth:user';
+
+-- Remap the rows the old default produced. 'user' meant auth:user; it is the only value the write
+-- path could not have produced, since credentialsUpdateRole validates every role it writes against
+-- the config.
+UPDATE credentials
+SET role = 'auth:user'
+WHERE
+  role = 'user';
+
+-- Refuse any role the application does not know, at write time rather than at read time. The set
+-- mirrors internal/config/permissions.config.yaml and must be updated with it; the backfill above
+-- runs first so no existing row violates it.
+ALTER TABLE credentials
+ADD CONSTRAINT credentials_role_check CHECK (
+  role IN (
+    'auth:anon',
+    'auth:user',
+    'auth:admin',
+    'auth:superadmin'
+  )
+);


### PR DESCRIPTION
Closes #1114, per your "agree with the fix". All three parts of the Approach — the guard, the schema, the backfill.

## The defect

`role` defaulted to `'user'` (`20250319184100`), which is not a configured role — every role is `auth:*`. Two lookups consumed it silently:

1. **Middleware** — `permissionsByRole[role]` yields `nil` for an unknown role, indistinguishable from "grants nothing". Affected accounts got a **403 byte-identical to a legitimate denial** — invisible in logs.
2. **`credentialsUpdateRole`** — the two roles read *from the database* were ranked via `Roles[role].Priority`; a map miss yields the zero `Role`, **priority 0** (same rank as `auth:anon`), so the hierarchy guards compared against a rank the account never held.

## Part 1 — the guard (the actual defect)

`config.Permissions.Priority(role) (int, error)` returns `ErrUnknownRole` naming the value. `credentialsUpdateRole` uses it for the two DB-read roles (the request role is already validated by `validate:"role"`, so its lookup can't fail — I still route it through the helper for symmetry).

The middleware distinguishes an unknown role from an ungranted one and returns **500**, not 403:

```go
permissions, known := middleware.permissionsByRole[role]
if !known {
    // a token bearing a role this system issued but cannot interpret is an
    // integrity fault, not a caller error
    return 500, ErrUnknownRole
}
```

500 is deliberate — the token was signed by this service, so an unrecognised role means the stored data or the config is inconsistent. That's an ops problem to page on, not a "you're not allowed" to show the user.

## Part 2 + 3 — schema and backfill

A new migration (`20260723140000`): points the default at `auth:user`, backfills the `'user'` rows, and adds a `CHECK` constraint.

**The constraint is provably safe against existing data**, which is why I could add it without seeing production: the write path validates every role it writes against the config (`ValidateCredentialsRole`), and new rows got the default — so the *only* value the table can hold outside `auth:*` is `'user'`, which the backfill (ordered before the constraint) remaps. The constraint's set mirrors `permissions.config.yaml` and must move with it (noted in the migration).

## The tests normalised the wrong shape

Exactly as the issue says: DAO tests inserted `'user'`, `'test_role_user'`, `'test_role'` — values the new constraint rejects. Those are the shape the guard exists to stop, so they now use `auth:*`. (Core tests use mocks, no DB — their literals stay, including my new `'user'` mock returns that drive the unknown-role path.)

New coverage on every path:
- `TestAuth/Error/UnknownRole` → 500, distinct from the 403 above.
- `TargetHasUnknownStoredRole` / `CallerHasUnknownStoredRole` → the two DB-read ranks error.
- `TestCredentialsRoleSchema` → the constraint rejects `'user'`, and a default insert resolves to `auth:user`.

**Red check** (against the reverted guards): middleware returns 403 where 500 is expected; both core cases lose their error. All against a **real Postgres** — and the DB is what enforces the constraint the schema test asserts.

Full suite green, `golangci-lint` 0 issues, `go generate` idempotent, prettier clean (checked the migration SQL locally this time — the `--check .` covers `.sql`).

## One thing for the operator

The issue's diagnostic — `SELECT role, count(*) FROM credentials GROUP BY 1` — I could not run (no prod access). The codebase analysis above proves `'user'` is the only possible bad value, so the migration is safe regardless. But if that query ever shows a value outside `auth:*` and `'user'`, the backfill needs extending before this deploys — flagging it so it's a conscious check, not an assumption.
