### PR TITLE
test(pkg-go): give the Go client its own test lane and first tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -131,6 +131,28 @@ jobs:
           coverage_file: coverage.txt
           modfile: gotestsum.mod
 
+  # pkg/go is the published Go client: the auth middleware wired against an injected claims
+  # verifier, and the role-inheritance resolution NewAuthHandler runs at startup. It has no
+  # network client and touches no database, so this lane stands up no services — unlike the
+  # sibling services, whose pkg tests are gRPC clients. It runs in its own lane because
+  # test-go filters to /internal, which leaves /pkg uncovered.
+  test-pkg:
+    runs-on: ubuntu-latest
+    needs: [lint-go]
+    permissions:
+      contents: read
+    outputs:
+      artifact-id: ${{ steps.test.outputs.artifact-id }}
+    steps:
+      - uses: a-novel-kit/workflows/go-actions/test-go@v1.23.1
+        id: test
+        with:
+          filter_extra_patterns: "| grep /pkg"
+          test_artifact: gotestpkg
+          coverage_artifact: gocoverpkg
+          coverage_file: coverage_pkg.txt
+          modfile: gotestsum.mod
+
   test-pkg-js:
     runs-on: ubuntu-latest
     needs: [build-database, build-standalone-rest]
@@ -432,15 +454,15 @@ jobs:
 
   report-codecov:
     runs-on: ubuntu-latest
-    needs: [test-go, test-pkg-js]
+    needs: [test-go, test-pkg, test-pkg-js]
     permissions:
       contents: read
     steps:
       - uses: a-novel-kit/workflows/generic-actions/codecov@v1.23.1
         with:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
-          coverage_files: coverage.txt,coverage/*
-          coverage_artifact_ids: ${{ needs.test-go.outputs.artifact-id }},${{ needs.test-pkg-js.outputs.artifact-id }}
+          coverage_files: coverage.txt,coverage_pkg.txt,coverage/*
+          coverage_artifact_ids: ${{ needs.test-go.outputs.artifact-id }},${{ needs.test-pkg.outputs.artifact-id }},${{ needs.test-pkg-js.outputs.artifact-id }}
 
   publish-docs:
     runs-on: ubuntu-latest

--- a/pkg/go/auth_test.go
+++ b/pkg/go/auth_test.go
@@ -1,0 +1,105 @@
+package serviceauthentication_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/require"
+
+	servicejsonkeys "github.com/a-novel/service-json-keys/v2/pkg/go"
+
+	"github.com/a-novel/service-authentication/v2/internal/config"
+	"github.com/a-novel/service-authentication/v2/internal/core"
+	serviceauthentication "github.com/a-novel/service-authentication/v2/pkg/go"
+)
+
+// fakeVerifier stands in for the JSON-keys claims verifier: it returns fixed claims for any
+// token, so the test exercises NewAuthHandler's role resolution without a running service.
+type fakeVerifier struct {
+	roles []string
+}
+
+func (f fakeVerifier) VerifyClaims(
+	_ context.Context, _ *servicejsonkeys.VerifyClaimsRequest,
+) (*core.AccessTokenClaims, error) {
+	return &core.AccessTokenClaims{Roles: f.roles}, nil
+}
+
+// NewAuthHandler resolves role inheritance transitively at startup and wraps it in lo.Must.
+// A role must grant every permission its ancestors do, and only those — the piece with real
+// logic in this package, and the one service-narrative-engine is about to mount routes against.
+func TestNewAuthHandlerResolvesInheritance(t *testing.T) {
+	t.Parallel()
+
+	// grandchild -> child -> parent. Each level adds one permission; grandchild must end up
+	// with all three.
+	permissions := serviceauthentication.Permissions{
+		Roles: map[string]config.Role{
+			"parent":     {Permissions: []string{"parent:read"}},
+			"child":      {Inherits: []string{"parent"}, Permissions: []string{"child:read"}},
+			"grandchild": {Inherits: []string{"child"}, Permissions: []string{"grandchild:read"}},
+		},
+	}
+
+	// gatedStatus mounts a route requiring `permission`, gates it with a token bearing `role`,
+	// and returns the status a request receives.
+	gatedStatus := func(t *testing.T, role, permission string) int {
+		t.Helper()
+
+		handler := serviceauthentication.NewAuthHandler(
+			fakeVerifier{roles: []string{role}}, permissions, config.LoggerDev,
+		)
+
+		router := chi.NewRouter()
+		handler(router, permission).Get("/", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+		req.Header.Set("Authorization", "Bearer token")
+
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		return rec.Code
+	}
+
+	t.Run("a role reaches an inherited permission", func(t *testing.T) {
+		t.Parallel()
+
+		// grandchild transitively inherits parent:read, two levels up.
+		require.Equal(t, http.StatusOK, gatedStatus(t, "grandchild", "parent:read"))
+		// and the intermediate one.
+		require.Equal(t, http.StatusOK, gatedStatus(t, "grandchild", "child:read"))
+		// and its own.
+		require.Equal(t, http.StatusOK, gatedStatus(t, "grandchild", "grandchild:read"))
+	})
+
+	t.Run("inheritance does not flow downward", func(t *testing.T) {
+		t.Parallel()
+
+		// parent must not gain a permission defined on a role that inherits it.
+		require.Equal(t, http.StatusForbidden, gatedStatus(t, "parent", "grandchild:read"))
+	})
+}
+
+// A permission map whose inheritance cannot be resolved — a role inheriting itself — is a
+// boot-time programming error, and NewAuthHandler's lo.Must turns it into a panic rather than a
+// silently empty permission set.
+func TestNewAuthHandlerPanicsOnCircularInheritance(t *testing.T) {
+	t.Parallel()
+
+	permissions := serviceauthentication.Permissions{
+		Roles: map[string]config.Role{
+			"a": {Inherits: []string{"b"}},
+			"b": {Inherits: []string{"a"}},
+		},
+	}
+
+	require.Panics(t, func() {
+		serviceauthentication.NewAuthHandler(fakeVerifier{}, permissions, config.LoggerDev)
+	})
+}


### PR DESCRIPTION
Closes #1147. The published `pkg/go` client had no tests and, after #1148 narrowed `test-go` to `grep /internal`, no lane to run them in — a test added there wouldn't run and nothing would say so.

## The lane, adapted to what auth's client actually is

The issue asks to mirror the two siblings, which carry a `podman-compose.go.pkg.test.yaml` standing up postgres + a standalone service. **I deliberately didn't**, because auth's `pkg/go` is not the same kind of package:

- `service-template` / `service-json-keys` `pkg/go` are **gRPC clients** — `NewClient(env.GrpcUrl)` then real RPCs — so their test-pkg lane must boot the service.
- auth's `pkg/go` is **middleware wiring** — `NewAuthHandler`, `PermissionsHandler`, the `Claims` alias. No network client, no database; the claims verifier is an injected interface.

So the `test-pkg` job stands up **no services** — it's the `test-go` action with `grep /pkg`, its own `coverage_pkg.txt` and artifacts, and nothing else. Standing up a service auth's tests never call would be cargo-culting the sibling shape past the point it applies.

`report-codecov` gains the lane: `coverage_pkg.txt` and the job's artifact id join the existing files, and `test-pkg` joins its `needs`.

## No compose env file, on purpose

Auth carries a **scoped** `go.internal` env (not a bare `go` one), so locally the CLI's catch-all target (stack#324) already runs `pkg/go` — the gap was CI-only. A `podman-compose.go.pkg.test.yaml` would either be an empty file or stand up unused services, and would double-cover `pkg` against that catch-all. The CI job needs no compose file — compose envs are a local `a-novel test` concept; the CI action just runs `go test`.

## The first tests

`NewAuthHandler` resolves role inheritance transitively at startup and wraps it in `lo.Must` — the piece with real logic, and the one **service-narrative-engine#428** is about to mount routes against. The tests drive it through the real handler with a fake verifier (no service):

- a **grandchild** role reaches a permission **two levels up** its inheritance chain (`grandchild → child → parent`), plus the intermediate and its own;
- inheritance **does not flow downward** — `parent` is denied a permission defined on a role that inherits it (403);
- a **circular** map panics at construction, rather than `lo.Must` resolving to a silently empty permission set.

Verified: `go test ./pkg/go` green with no database. Full suite green against a real Postgres, `golangci-lint` 0 issues, `go generate` idempotent, and I ran prettier on `main.yaml` locally (it formats YAML) — clean.

## One operator step

Required checks are derived by `a-novel repo update`, not a static file, so `test-pkg` becomes required when that's next run — flagging it so the new gate isn't a surprise.

## Related

- a-novel/service-template#404 — the same shape for `cmd/`, which no lane covers in any service. Left as its own issue.
