### PR TITLE
fix(dao): drop repeatable-read isolation from short-code insert

### DIFF
--- a/internal/dao/pg.shortCodeInsert.go
+++ b/internal/dao/pg.shortCodeInsert.go
@@ -18,9 +18,12 @@ import (
 )
 
 // ErrShortCodeInsertNested is returned when [ShortCodeInsert.Exec] is called inside
-// a transaction someone else opened. The operation needs repeatable-read isolation,
-// and a nested transaction joins the outer one and silently inherits its isolation
-// level, so the call is refused.
+// a transaction someone else opened. The operation must own its transaction so it
+// runs at the read-committed isolation it sets: a nested call joins the outer
+// transaction and silently inherits its isolation level (WithinTx ignores opts when
+// nested). A caller's repeatable-read level would turn the override path's UPDATE into
+// a serialization failure, so the nested call is refused rather than run at the wrong
+// isolation.
 var ErrShortCodeInsertNested = errors.New("short code insert cannot run inside another transaction")
 
 //go:embed pg.shortCodeInsert.sql
@@ -33,10 +36,10 @@ var shortCodeInsertQuery string
 // mapped onto this sentinel. Callers match it with errors.Is either way.
 var ErrShortCodeInsertAlreadyExists = errors.New("short code already exists")
 
-// ShortCodeInsertRequest is the input to [ShortCodeInsert.Exec]. The insert runs at
-// repeatable-read isolation over a partial unique index on the active (target, usage)
-// subset, so concurrent inserts cannot produce duplicates: the loser sees
-// [ErrShortCodeInsertAlreadyExists].
+// ShortCodeInsertRequest is the input to [ShortCodeInsert.Exec]. Correctness rests on
+// the partial unique index on the active (target, usage) subset, not on the isolation
+// level, so concurrent inserts cannot produce duplicates at read-committed: the loser
+// sees [ErrShortCodeInsertAlreadyExists].
 type ShortCodeInsertRequest struct {
 	// See ShortCode.ID.
 	ID uuid.UUID
@@ -76,15 +79,23 @@ func (dao *ShortCodeInsert) Exec(ctx context.Context, request *ShortCodeInsertRe
 		attribute.Bool("shortCode.override", request.Override),
 	)
 
-	// Repeatable-read is required. The conflict check and the insert see one snapshot.
-	// A nested transaction inherits the caller's isolation level, so callers sequence the
-	// two operations themselves.
+	// The operation must own its transaction so the isolation it sets actually
+	// applies; a nested call would inherit the caller's level instead, so it is
+	// refused.
 	if postgres.InTx(ctx) {
 		return nil, otel.ReportError(span, ErrShortCodeInsertNested)
 	}
 
 	entity := new(ShortCode)
-	txOptions := &sql.TxOptions{Isolation: sql.LevelRepeatableRead}
+	// Read-committed, deliberately. The partial unique index (target, usage) WHERE
+	// deleted_at IS NULL enforces at-most-one-active at every isolation level, so it —
+	// not the isolation — is the correctness guarantee. Repeatable-read would buy no
+	// extra safety and would turn two concurrent overrides into a 40001 serialization
+	// failure (the losing UPDATE hits a row the winner already committed), surfacing as
+	// a 500 where the caller should see the ordinary already-exists path. Under
+	// read-committed that UPDATE blocks and re-evaluates, and the loser's insert takes
+	// the mapped 23505 route below.
+	txOptions := &sql.TxOptions{Isolation: sql.LevelReadCommitted}
 
 	err := postgres.WithinTx(ctx, txOptions, func(ctx context.Context) error {
 		var err error
@@ -123,9 +134,10 @@ func (dao *ShortCodeInsert) Exec(ctx context.Context, request *ShortCodeInsertRe
 			request.ExpiresAt,
 		).Scan(ctx, entity)
 		if err != nil {
-			// The partial unique index catches conflicts the in-transaction check
-			// missed under concurrent inserts. Map its SQLSTATE 23505 onto the
-			// sentinel callers already match on.
+			// The partial unique index is the real guard: it catches conflicts the
+			// in-transaction check missed under concurrent inserts, including two
+			// simultaneous overrides racing for the same pair. Map its SQLSTATE 23505
+			// onto the sentinel callers already match on.
 			var pgErr pgdriver.Error
 			if errors.As(err, &pgErr) && pgErr.Field('C') == "23505" {
 				err = errors.Join(err, ErrShortCodeInsertAlreadyExists)

--- a/internal/dao/pg.shortCodeInsert_test.go
+++ b/internal/dao/pg.shortCodeInsert_test.go
@@ -2,6 +2,7 @@ package dao_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -307,4 +308,106 @@ func TestShortCodeInsert(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestShortCodeInsertConcurrentOverride races two Override inserts for one
+// (target, usage) pair against a single active code they both contend on. The partial
+// unique index guarantees at most one active row survives, so on every interleaving
+// the loser must take the ordinary already-exists path — never a raw SQLSTATE 40001
+// serialization failure, which a repeatable-read transaction would surface here as a
+// 500. Several rounds run so the two transactions reliably overlap at least once; a
+// repeatable-read implementation fails the round where they do.
+func TestShortCodeInsertConcurrentOverride(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Round(time.Second)
+	hourAgo := time.Now().Add(-time.Hour).UTC().Round(time.Second)
+	hourLater := time.Now().Add(time.Hour).UTC().Round(time.Second)
+
+	shortCodeDAO := dao.NewShortCodeInsert()
+
+	postgres.RunDBTest(t, configtest.PostgresPreset, migrations.Migrations, func(ctx context.Context, t *testing.T) {
+		t.Helper()
+
+		db, err := postgres.GetContext(ctx)
+		require.NoError(t, err)
+
+		// Seed the single active code the first round's overrides contend on. Every
+		// later round contends on the previous round's surviving row.
+		seed := []*dao.ShortCode{
+			{
+				ID:        uuid.New(),
+				Code:      "seed-code",
+				Usage:     "test-usage",
+				Target:    "test-target",
+				Data:      []byte("seed-data"),
+				CreatedAt: hourAgo,
+				ExpiresAt: hourLater,
+			},
+		}
+		_, err = db.NewInsert().Model(&seed).Exec(ctx)
+		require.NoError(t, err)
+
+		const rounds = 10
+
+		for round := range rounds {
+			// Two overrides for the same pair, released together so their transactions
+			// overlap and genuinely contend on the current active row's override UPDATE.
+			requests := []*dao.ShortCodeInsertRequest{
+				{
+					ID: uuid.New(), Code: "override-a", Usage: "test-usage", Target: "test-target",
+					Data: []byte("data-a"), Now: now, ExpiresAt: hourLater, Override: true,
+				},
+				{
+					ID: uuid.New(), Code: "override-b", Usage: "test-usage", Target: "test-target",
+					Data: []byte("data-b"), Now: now, ExpiresAt: hourLater, Override: true,
+				},
+			}
+
+			start := make(chan struct{})
+			errs := make([]error, len(requests))
+
+			var wg sync.WaitGroup
+			for i, request := range requests {
+				wg.Add(1)
+
+				go func() {
+					defer wg.Done()
+
+					<-start
+
+					_, errs[i] = shortCodeDAO.Exec(ctx, request)
+				}()
+			}
+
+			close(start)
+			wg.Wait()
+
+			// The loser never sees a raw serialization failure — only the mapped
+			// already-exists sentinel — and at least one override always lands.
+			successes := 0
+
+			for _, err := range errs {
+				if err == nil {
+					successes++
+
+					continue
+				}
+
+				require.ErrorIs(t, err, dao.ErrShortCodeInsertAlreadyExists)
+			}
+
+			require.GreaterOrEqualf(t, successes, 1, "round %d: at least one override must succeed", round)
+
+			// The invariant the unique index protects: exactly one active row remains.
+			activeCount, err := db.NewSelect().
+				Model((*dao.ShortCode)(nil)).
+				Where("target = ?", "test-target").
+				Where("usage = ?", "test-usage").
+				Where("deleted_at IS NULL").
+				Count(ctx)
+			require.NoError(t, err)
+			require.Equalf(t, 1, activeCount, "round %d: exactly one active short code must remain", round)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- `ShortCodeInsert` ran at repeatable-read, where two concurrent inserts for the same `(target, usage)` — a double-clicked "resend", a retried request — make the loser's override `UPDATE` raise **SQLSTATE 40001** *before* the insert, so the `23505 → already-exists` mapping never runs and the caller gets a raw **500** instead of the documented `ErrShortCodeInsertAlreadyExists`.
- Repeatable-read was never load-bearing: the partial unique index `(target, usage) WHERE deleted_at IS NULL` enforces at-most-one-active **at every isolation level**, and that index — not the isolation — is the correctness guarantee. Since the only invariant is constraint-backed, no write-skew is possible, so dropping to **read-committed** loses nothing and removes the 40001 class entirely: the losing `UPDATE` blocks and re-evaluates, then its insert takes the mapped `23505 → already-exists` route.

## Layers changed

- **DAO** (`internal/dao/pg.shortCodeInsert.go`): isolation `LevelRepeatableRead → LevelReadCommitted`; refreshed the three doc comments that claimed repeatable-read was required.

## Review notes

- **The nested-transaction guard stays** (`ErrShortCodeInsertNested`), with its rationale rewritten. It still earns its place: a nested `WithinTx` silently *ignores* the opts we pass, so a future caller wrapping this in a repeatable-read transaction would reintroduce the exact 40001. Forcing the operation to own its transaction keeps the read-committed choice real.
- **Why read-committed is safe on the override path** (worth scrutinising): the losing `UPDATE` blocks on the winner's row lock, then EPQ re-evaluates against the committed version — the row is now soft-deleted so it falls out of the `WHERE`, and rows the winner committed *after* the loser's statement snapshot are invisible to it, so the loser never soft-deletes the winner's fresh row. Its insert then collides with the unique index → `23505` → already-exists.

## Breaking changes

None. Internal DAO behaviour only; no API, schema, or exported-symbol change.

## Test plan

- [x] `pnpm lint:go` clean
- [x] `a-novel test --type=go -y` passes (full suite green)
- [x] New `TestShortCodeInsertConcurrentOverride`: 10 rounds of two `Override` inserts racing on one active row; asserts the loser only ever sees `ErrShortCodeInsertAlreadyExists` (never a raw serialization failure) and exactly one active row survives
- [ ] CI green

Closes #1117