### PR TITLE
chore(ci): add the shared lint-shell and lint-dockerfile jobs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -78,6 +78,22 @@ jobs:
           client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}
           lint_action: "lint:ci"
 
+  lint-shell:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: a-novel-kit/workflows/generic-actions/lint-shell@v1.25.1
+
+  lint-dockerfile:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: a-novel-kit/workflows/generic-actions/lint-dockerfile@v1.25.1
+
   test-go:
     needs: [lint-go, build-database]
     runs-on: ubuntu-latest

--- a/scripts/mjml.sh
+++ b/scripts/mjml.sh
@@ -4,7 +4,9 @@
 
 set -e
 
-for i in `find . -name "*.mjml" -type f`
-do
-  pnpm mjml $i --config.beautify false --config.minify false -o ${i%.*}.html
-done
+# NUL-delimited, so a template path containing a space or newline survives the split. Read through
+# process substitution rather than a pipe, so the loop stays in this shell and `set -e` still sees a
+# failed render instead of it being swallowed by a subshell.
+while IFS= read -r -d '' i; do
+  pnpm mjml "$i" --config.beautify false --config.minify false -o "${i%.*}.html"
+done < <(find . -name "*.mjml" -type f -print0)


### PR DESCRIPTION
## Summary

- Adopts the shared **`lint-shell`** and **`lint-dockerfile`** jobs from `a-novel-kit/workflows`,
  pinned at **v1.25.1** — the version the other 15 refs in this `main.yaml` already use.
- This was the last repo in the fleet that needed either linter and had neither. With it, every repo
  in both orgs is either adopted or has nothing to lint.
- Both gate from the first run: no advisory phase.

## The script fix comes first for a reason

All 5 Dockerfiles were already hadolint-clean, but `scripts/mjml.sh` carried 4 real shellcheck
findings, so `lint-shell` could not gate until they were fixed:

```
scripts/mjml.sh:7:10  SC2044  For loops over find output are fragile
scripts/mjml.sh:7:10  SC2006  legacy backticks
scripts/mjml.sh:9:13  SC2086  Double quote to prevent globbing and word splitting
scripts/mjml.sh:9:65  SC2086  (same, on the -o argument)
```

These are one defect, not four style nits: `for i in $(find …)` word-splits on whitespace, so a
template path containing a space would reach `mjml` as two arguments — the render fails, or worse
writes to a truncated `-o` path. The loop is now NUL-delimited (`find -print0` + `read -r -d ''`).

It reads through **process substitution rather than a pipe** deliberately: a piped `while` runs in a
subshell, where a failed render would be swallowed instead of tripping `set -e`.

**Verified behaviour-identical** by stubbing `pnpm` and diffing the emitted command lines — both
loops produce the same 7 renders in the same order.

## Follow-up for the merger

Both jobs become **required checks** on the next `a-novel repo update`; until that runs they execute
but gate nothing. Note `update` reads the working tree and silently skips a checkout that is not on
its default branch.

## Breaking changes

None. The script's contract is unchanged — same inputs, same outputs, same order.

## Test plan

- [x] `shellcheck -f gcc $(git ls-files '*.sh')` — **0 findings** (was 4)
- [x] `hadolint` over all 5 Dockerfiles — **0 findings**
- [x] `bash -n scripts/mjml.sh`, and old-vs-new loop output proven identical over all 7 templates
- [x] `prettier --check .github/workflows/main.yaml` clean
- [ ] CI green
