### PR TITLE
ci(ci): cut cost-only job edges from the main graph

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,12 +7,6 @@ on:
     branches:
       - "**"
 
-# A `needs:` edge here means the downstream job cannot run without something the upstream one
-# produces — an image digest, a coverage artifact ID, a file on disk. Edges that only expressed
-# "don't spend a runner if the previous check failed" are gone: the jobs sit on separate runners
-# with separate checkouts, so an upstream verdict never changes a downstream one, and each such
-# edge cost the entire graph one job's latency. merge-gate still holds the merge itself, so a red
-# check blocks the PR whether or not the rest of the graph ran.
 jobs:
   generated-go:
     runs-on: ubuntu-latest
@@ -38,19 +32,12 @@ jobs:
       contents: read
       packages: read
     steps:
-      # This used to inline pull-bot, setup-node, the registry config and the install by hand —
-      # the same sequence node-actions/setup-node ships, minus its pnpm cache and pinned to
-      # `node-version: latest` where the shared action tracks lts/*. Two copies of one setup drift;
-      # this one already had.
       - uses: a-novel-kit/workflows/node-actions/setup-node@v1.26.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
           client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}
-      # generate:mjml, not the `generate` umbrella. That umbrella also runs generate:go, which the
-      # generated-go job above already runs — and runs correctly, against the toolchain go.mod
-      # pins, where this job has no setup-go step and would reach for whatever Go the runner image
-      # happens to ship. One `go generate` per workflow, from the pinned toolchain.
+      # Not the `generate` umbrella: its generate:go leg is generated-go's, which has the setup-go.
       - name: pnpm generate:mjml
         shell: bash
         run: pnpm generate:mjml
@@ -151,9 +138,6 @@ jobs:
           version: "1.28.0"
 
   test-go:
-    # build-database only: it hands over the image digest below. lint-go is not a dependency —
-    # it runs on its own runner against its own checkout, so its verdict cannot change this
-    # job's, and waiting on it only pushed the whole graph back by a lint run.
     needs: [build-database]
     runs-on: ubuntu-latest
     permissions:
@@ -464,10 +448,6 @@ jobs:
           POSTGRES_DB: postgres
           POSTGRES_HOST_AUTH_METHOD: scram-sha-256
           POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        # The only postgres service in the fleet that was missing this. Steps start once the
-        # container is up, which is earlier than the server accepts connections, and the first
-        # step here is run-migrations — an unguarded race whose only cover was the setup-go and
-        # module download that happen to run ahead of it.
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -554,10 +534,7 @@ jobs:
   publish-docs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' && success()
-    # This job deploys two committed files, openapi.html and openapi.yaml, and builds nothing.
-    # lint-node is the gate that matches: its `lint:ci` runs redocly over openapi.yaml and
-    # prettier over both. It used to hang off build-js, which compiles the TypeScript client and
-    # never reads either file — a chain through test-pkg-js and the whole Go lane for no signal.
+    # lint-node is what checks the openapi files this deploys.
     needs: [lint-node]
     # GitHub Pages allows a single deployment in flight per site; without this
     # group, concurrent master runs fail with "in progress deployment" errors.

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,6 +7,12 @@ on:
     branches:
       - "**"
 
+# A `needs:` edge here means the downstream job cannot run without something the upstream one
+# produces — an image digest, a coverage artifact ID, a file on disk. Edges that only expressed
+# "don't spend a runner if the previous check failed" are gone: the jobs sit on separate runners
+# with separate checkouts, so an upstream verdict never changes a downstream one, and each such
+# edge cost the entire graph one job's latency. merge-gate still holds the merge itself, so a red
+# check blocks the PR whether or not the rest of the graph ran.
 jobs:
   generated-go:
     runs-on: ubuntu-latest
@@ -62,7 +68,6 @@ jobs:
 
   lint-go:
     runs-on: ubuntu-latest
-    needs: [generated-go]
     permissions:
       contents: read
     steps:
@@ -154,7 +159,10 @@ jobs:
           version: "1.28.0"
 
   test-go:
-    needs: [lint-go, build-database]
+    # build-database only: it hands over the image digest below. lint-go is not a dependency —
+    # it runs on its own runner against its own checkout, so its verdict cannot change this
+    # job's, and waiting on it only pushed the whole graph back by a lint run.
+    needs: [build-database]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -215,7 +223,6 @@ jobs:
   # test-go filters to /internal, which leaves /pkg uncovered.
   test-pkg:
     runs-on: ubuntu-latest
-    needs: [lint-go]
     permissions:
       contents: read
     outputs:
@@ -391,7 +398,7 @@ jobs:
 
   build-init:
     runs-on: ubuntu-latest
-    needs: [test-go, build-database]
+    needs: [build-database]
     permissions:
       contents: read
       packages: write
@@ -433,7 +440,7 @@ jobs:
             -e SUPER_ADMIN_PASSWORD="${SUPER_ADMIN_PASSWORD}"
 
   build-rest:
-    needs: [test-go, build-database]
+    needs: [build-database]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -507,7 +514,6 @@ jobs:
             -e PLATFORM_AUTH_URL="${PLATFORM_AUTH_URL}"
 
   build-standalone-rest:
-    needs: [test-go]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -529,7 +535,6 @@ jobs:
           skip_healthcheck: true
 
   build-js:
-    needs: [test-pkg-js]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -557,7 +562,11 @@ jobs:
   publish-docs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' && success()
-    needs: [build-js]
+    # This job deploys two committed files, openapi.html and openapi.yaml, and builds nothing.
+    # lint-node is the gate that matches: its `lint:ci` runs redocly over openapi.yaml and
+    # prettier over both. It used to hang off build-js, which compiles the TypeScript client and
+    # never reads either file — a chain through test-pkg-js and the whole Go lane for no signal.
+    needs: [lint-node]
     # GitHub Pages allows a single deployment in flight per site; without this
     # group, concurrent master runs fail with "in progress deployment" errors.
     concurrency:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -465,6 +465,15 @@ jobs:
           POSTGRES_DB: postgres
           POSTGRES_HOST_AUTH_METHOD: scram-sha-256
           POSTGRES_INITDB_ARGS: --auth=scram-sha-256
+        # The only postgres service in the fleet that was missing this. Steps start once the
+        # container is up, which is earlier than the server accepts connections, and the first
+        # step here is run-migrations — an unguarded race whose only cover was the setup-go and
+        # module download that happen to run ahead of it.
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
       service-json-keys:
         image: ghcr.io/a-novel/service-json-keys/standalone-grpc:v2.4.1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,33 +38,25 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/pull-bot@v1.26.1
-        id: app_token
+      # This used to inline pull-bot, setup-node, the registry config and the install by hand —
+      # the same sequence node-actions/setup-node ships, minus its pnpm cache and pinned to
+      # `node-version: latest` where the shared action tracks lts/*. Two copies of one setup drift;
+      # this one already had.
+      - uses: a-novel-kit/workflows/node-actions/setup-node@v1.26.1
         with:
-          client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
-      - uses: actions/setup-node@v7
-        with:
-          node-version: latest
-      # `npm install -g pnpm` took whatever was newest, which need not be the
-      # pnpm this repo declares. action-setup reads packageManager from
-      # package.json, so CI runs the version the repo pins.
-      - uses: pnpm/action-setup@v6
-      - name: setup github registry
+          client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}
+      # generate:mjml, not the `generate` umbrella. That umbrella also runs generate:go, which the
+      # generated-go job above already runs — and runs correctly, against the toolchain go.mod
+      # pins, where this job has no setup-go step and would reach for whatever Go the runner image
+      # happens to ship. One `go generate` per workflow, from the pinned toolchain.
+      - name: pnpm generate:mjml
         shell: bash
-        run: |
-          pnpm config set "@a-novel:registry" "https://npm.pkg.github.com"
-          pnpm config set "@a-novel-kit:registry" "https://npm.pkg.github.com"
-          pnpm config set "//npm.pkg.github.com/:_authToken" "${{ secrets.GITHUB_TOKEN }}"
-      - name: install dependencies
-        shell: bash
-        run: pnpm i --frozen-lockfile
-      - name: pnpm
-        shell: bash
-        run: pnpm generate
+        run: pnpm generate:mjml
       - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.26.1
         with:
-          fail_message: pnpm definitions are not up-to-date, please run 'pnpm generate' and commit the changes
+          fail_message: mail templates are not up-to-date, please run 'pnpm generate' and commit the changes
 
   lint-go:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fleet-wide sweep over `main.yaml`. A `needs:` edge now exists only where the downstream job
consumes something the upstream one produces — an image digest, a coverage artifact ID, a file on
disk. Edges that only meant *don't spend a runner if the previous check failed* are gone: those jobs
run on separate runners against separate checkouts, so an upstream verdict never changed a
downstream one, and each such edge cost the whole graph one job's latency.

This PR carries three commits, one per kind of change.

**`fix(ci): gate build-rest's postgres on a health check`** — `build-rest`'s
`postgres-authentication` service declared no `--health-cmd`, the only postgres service in the fleet
missing one. Job steps start when the container is up, which is earlier than the server accepts
connections, and the first step is `run-migrations`. The race was covered only by the `setup-go` and
module download that happen to run ahead of it.

**`refactor(ci): reuse the shared node setup in generated-pnpm`** — that job inlined `pull-bot`,
`setup-node`, the registry config and the install by hand: the sequence `node-actions/setup-node`
ships, minus its pnpm cache, and pinned to `node-version: latest` where the shared action tracks
`lts/*`. It was the slowest job in the repo at 85s. It also ran the `pnpm generate` umbrella, whose
`generate:go` leg duplicates the `generated-go` job — and duplicates it *worse*, since this job has
no `setup-go` and reached for whatever Go the runner image shipped rather than what `go.mod` pins.
It now runs `generate:mjml`, the only leg that was uniquely its own.

**`ci(ci): cut cost-only job edges from the main graph`** — the sweep, plus:

- `test-pkg` no longer waits on `lint-go`. It stands up no services and touches no database.
- **`publish-docs` now hangs off `lint-node`, not `build-js`.** It deploys two committed files,
  `openapi.html` and `openapi.yaml`, and builds nothing. `lint-node` is the job that actually
  validates them (`lint:ci` → `lint:js` → `redocly lint openapi.yaml`, plus `prettier --check` over
  both). `build-js` compiles the TypeScript client and reads neither file.

## Effect

Critical path, simulated against the per-job durations of this repo's last green `master` run:

| | before | after |
| --- | --- | --- |
| whole run | 5.6 min | **2.1 min** |
| time to all required checks (i.e. mergeable) | 5.0 min | **2.0 min** (−60%) |

The run is now bounded by `build-rest`.

A red check still blocks the merge — `merge-gate` holds that, not the graph shape. What changed is
that a failing lint no longer withholds the test result, so a run reports every failure it has in
one pass instead of one layer at a time.

## Required checks

No job was added, renamed or removed. The set of job IDs `main.yaml` declares is identical to
`master`'s, so the derived required-check list is unchanged and **no `a-novel repo update` is
needed**.

## Test plan

- [x] every file parses; no cycles; every `needs:` names a declared job
- [x] every `needs.X` expression names a job that is actually in that job's `needs` list
- [x] `prettier --check` clean
- [x] `zizmor` 1.28.0 clean, run offline with the fleet baseline config
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)