### PR TITLE
feat(migrations): verify reversible migration history

### DIFF
--- a/.github/workflows/approve-pr.yaml
+++ b/.github/workflows/approve-pr.yaml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/approve-pr@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/approve-pr@v1.27.1
         with:
           pull_request: ${{ inputs.pull_request }}
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}

--- a/.github/workflows/auto-approve-dependabot.yaml
+++ b/.github/workflows/auto-approve-dependabot.yaml
@@ -20,7 +20,7 @@ jobs:
     # the callee mints a scoped App token and declares permissions: {}; the caller sets the ceiling, so it must not hand down
     # the repository default.
     permissions: {}
-    uses: a-novel-kit/workflows/.github/workflows/auto-approve-dependabot-run.yaml@v1.26.2
+    uses: a-novel-kit/workflows/.github/workflows/auto-approve-dependabot-run.yaml@v1.27.1
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       dependency_bot_login: ${{ vars.DEPENDENCY_BOT_LOGIN }}

--- a/.github/workflows/auto-assign-author.yaml
+++ b/.github/workflows/auto-assign-author.yaml
@@ -10,6 +10,6 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/assign-bot@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/assign-bot@v1.27.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/derive-status.yaml
+++ b/.github/workflows/derive-status.yaml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: read
       issues: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.27.1
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/epic-freeze.yaml
+++ b/.github/workflows/epic-freeze.yaml
@@ -33,7 +33,7 @@ jobs:
     # a stray forward is sweep-only, so a per-PR run can never re-enqueue.
     permissions: {}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.27.1
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/epic-rollback.yaml
+++ b/.github/workflows/epic-rollback.yaml
@@ -52,7 +52,7 @@ jobs:
     # the repository default.
     permissions:
       contents: read
-    uses: a-novel-kit/workflows/.github/workflows/epic-rollback-run.yaml@v1.26.2
+    uses: a-novel-kit/workflows/.github/workflows/epic-rollback-run.yaml@v1.27.1
     with:
       epic_number: ${{ inputs.epic_number }}
       confirm: ${{ inputs.confirm }}

--- a/.github/workflows/hotfix.yaml
+++ b/.github/workflows/hotfix.yaml
@@ -51,7 +51,7 @@ jobs:
     permissions:
       contents: write
       actions: read
-    uses: a-novel-kit/workflows/.github/workflows/hotfix-run.yaml@v1.26.2
+    uses: a-novel-kit/workflows/.github/workflows/hotfix-run.yaml@v1.27.1
     with:
       line: ${{ inputs.line }}
       fix_ref: ${{ inputs.fix_ref }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,13 +5,50 @@ on:
     tags-ignore:
       - "**"
     branches:
-      - "**"
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  merge_group:
 
 jobs:
-  generated-go:
+  check-migration-snapshots:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: a-novel-kit/workflows/generic-actions/check-append-only@v1.27.1
+        with:
+          path: internal/models/migrations/testdata/schema
+          base: ${{ github.event.pull_request.base.sha }}
+
+  generated-go:
+    needs: [build-database]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: ghcr.io/a-novel/service-authentication/database@${{ needs.build-database.outputs.digest }}
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
+          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
       - uses: actions/checkout@v7
         with:
@@ -22,7 +59,7 @@ jobs:
       - name: go generate
         shell: bash
         run: go generate ./...
-      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.27.1
         with:
           fail_message: go generate definitions are not up-to-date, please run 'go generate ./...' and commit the changes
 
@@ -32,7 +69,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/setup-node@v1.26.2
+      - uses: a-novel-kit/workflows/node-actions/setup-node@v1.27.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -41,7 +78,7 @@ jobs:
       - name: pnpm generate:mjml
         shell: bash
         run: pnpm generate:mjml
-      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.27.1
         with:
           fail_message: mail templates are not up-to-date, please run 'pnpm generate' and commit the changes
 
@@ -50,7 +87,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.26.2
+      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.27.1
 
   lint-node:
     runs-on: ubuntu-latest
@@ -58,7 +95,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.26.2
+      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.27.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -73,7 +110,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/generic-actions/lint-shell@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/lint-shell@v1.27.1
         with:
           # renovate: datasource=github-releases depName=koalaman/shellcheck
           version: "0.11.0"
@@ -86,7 +123,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/generic-actions/lint-dockerfile@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/lint-dockerfile@v1.27.1
         with:
           # renovate: datasource=github-releases depName=hadolint/hadolint
           version: "2.14.0"
@@ -100,7 +137,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/security-actions/lint-semgrep@v1.26.2
+      - uses: a-novel-kit/workflows/security-actions/lint-semgrep@v1.27.1
         with:
           ruleset: service
           # renovate: datasource=docker depName=semgrep/semgrep
@@ -116,7 +153,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/security-actions/scan-secrets@v1.26.2
+      - uses: a-novel-kit/workflows/security-actions/scan-secrets@v1.27.1
         with:
           config: .gitleaks.toml
           # renovate: datasource=github-releases depName=gitleaks/gitleaks
@@ -132,7 +169,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/security-actions/lint-workflows@v1.26.2
+      - uses: a-novel-kit/workflows/security-actions/lint-workflows@v1.27.1
         with:
           # renovate: datasource=docker depName=ghcr.io/zizmorcore/zizmor
           version: "1.28.0"
@@ -182,7 +219,7 @@ jobs:
         run: |
           go run ./cmd/init
           go run ./cmd/init
-      - uses: a-novel-kit/workflows/go-actions/test-go@v1.26.2
+      - uses: a-novel-kit/workflows/go-actions/test-go@v1.27.1
         id: test
         with:
           filter_extra_patterns: "| grep /internal"
@@ -204,7 +241,7 @@ jobs:
     outputs:
       artifact-id: ${{ steps.test.outputs.artifact-id }}
     steps:
-      - uses: a-novel-kit/workflows/go-actions/test-go@v1.26.2
+      - uses: a-novel-kit/workflows/go-actions/test-go@v1.27.1
         id: test
         with:
           filter_extra_patterns: "| grep /pkg"
@@ -299,7 +336,7 @@ jobs:
       SUPER_ADMIN_PASSWORD: admin
       MAIL_HOST: http://0.0.0.0:8025
     steps:
-      - uses: a-novel-kit/workflows/node-actions/test-node@v1.26.2
+      - uses: a-novel-kit/workflows/node-actions/test-node@v1.27.1
         id: test
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -324,7 +361,7 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         id: build
         with:
           file: builds/database.Dockerfile
@@ -365,7 +402,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.27.1
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -405,7 +442,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.27.1
         with:
           file: builds/init.Dockerfile
           image_name: ${{ github.repository }}/jobs/init
@@ -474,7 +511,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -498,7 +535,7 @@ jobs:
     # integration run), so this job only builds + pushes it. skip_healthcheck
     # drops the redundant smoke run and the container constellation it needed.
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         id: build
         with:
           file: builds/standalone.rest.Dockerfile
@@ -512,7 +549,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/build-node@v1.26.2
+      - uses: a-novel-kit/workflows/node-actions/build-node@v1.27.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -525,7 +562,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.27.1
         with:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
           coverage_files: coverage.txt,coverage_pkg.txt,coverage/*

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -34,7 +34,7 @@ jobs:
     # the callee mints its own App token and declares permissions: {}; the caller sets the ceiling, so it must not hand down
     # the repository default.
     permissions: {}
-    uses: a-novel-kit/workflows/.github/workflows/merge-gate-run.yaml@v1.26.2
+    uses: a-novel-kit/workflows/.github/workflows/merge-gate-run.yaml@v1.27.1
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       kill_switch: ${{ vars.AGENT_KILL_SWITCH }}

--- a/.github/workflows/node-audit.yaml
+++ b/.github/workflows/node-audit.yaml
@@ -11,7 +11,7 @@ jobs:
       contents: write
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/audit@v1.26.2
+      - uses: a-novel-kit/workflows/node-actions/audit@v1.27.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release-train.yaml
+++ b/.github/workflows/release-train.yaml
@@ -39,7 +39,7 @@ jobs:
     # the repository default.
     permissions:
       contents: read
-    uses: a-novel-kit/workflows/.github/workflows/release-train-run.yaml@v1.26.2
+    uses: a-novel-kit/workflows/.github/workflows/release-train-run.yaml@v1.27.1
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       epic_number: ${{ inputs.epic_number }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
       tag: ${{ steps.core.outputs.tag }}
     steps:
       - id: core
-        uses: a-novel-kit/workflows/publish-actions/release-core@v1.26.2
+        uses: a-novel-kit/workflows/publish-actions/release-core@v1.27.1
         with:
           # renovate: datasource=go depName=github.com/a-novel-kit/stack/cli
           cli_version: "1.7.5"
@@ -73,7 +73,7 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         with:
           file: builds/database.Dockerfile
           image_name: ${{ github.repository }}/database
@@ -115,7 +115,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.27.1
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -157,7 +157,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.27.1
         with:
           file: builds/init.Dockerfile
           image_name: ${{ github.repository }}/jobs/init
@@ -223,7 +223,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -290,7 +290,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         with:
           file: builds/standalone.rest.Dockerfile
           image_name: ${{ github.repository }}/standalone-rest
@@ -312,7 +312,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: a-novel-kit/workflows/publish-actions/npm@v1.26.2
+      - uses: a-novel-kit/workflows/publish-actions/npm@v1.27.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}
@@ -334,7 +334,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.27.1
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
       security-events: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/renovate@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/renovate@v1.27.1
         with:
           allowed_commands: |
             [

--- a/internal/models/migrations/migrations.go
+++ b/internal/models/migrations/migrations.go
@@ -9,5 +9,6 @@ import (
 // Migrations holds the up and down schema migration files, discovered by their
 // timestamped filenames and applied in order by the migration runner.
 //
+//go:generate env GOLIB_UPDATE_SNAPSHOTS=1 go test -run ^TestMigrationRoundtrip$
 //go:embed *.sql
 var Migrations embed.FS

--- a/internal/models/migrations/migrations_test.go
+++ b/internal/models/migrations/migrations_test.go
@@ -1,0 +1,27 @@
+package migrations_test
+
+import (
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/a-novel-kit/golib/postgres"
+
+	"github.com/a-novel/service-authentication/v2/internal/config/configtest"
+	"github.com/a-novel/service-authentication/v2/internal/models/migrations"
+)
+
+func TestMigrationRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	_, err := fs.Stat(migrations.Migrations, "testdata")
+	require.ErrorIs(t, err, fs.ErrNotExist)
+
+	postgres.RunMigrationRoundtripTest(t, configtest.PostgresPreset, migrations.Migrations,
+		&postgres.RoundtripOptions{
+			Fixtures:  os.DirFS("testdata/fixtures"),
+			Snapshots: "testdata/schema",
+		})
+}

--- a/internal/models/migrations/testdata/fixtures/20250126124400_credentials_table.sql
+++ b/internal/models/migrations/testdata/fixtures/20250126124400_credentials_table.sql
@@ -1,0 +1,11 @@
+-- A fixture runs after its matching migration and seeds data for the next migration.
+INSERT INTO
+  credentials (id, email, password, created_at, updated_at)
+VALUES
+  (
+    '00000000-0000-0000-0000-000000000001',
+    'roundtrip@example.com',
+    NULL,
+    '2025-01-26T12:44:00Z',
+    '2025-01-26T12:44:00Z'
+  );

--- a/internal/models/migrations/testdata/fixtures/20250208151300_short_codes_table.sql
+++ b/internal/models/migrations/testdata/fixtures/20250208151300_short_codes_table.sql
@@ -1,0 +1,28 @@
+-- Duplicate active rows exercise the cleanup before the unique partial index is created.
+INSERT INTO
+  short_codes (id, code, usage, target, created_at, expires_at)
+VALUES
+  (
+    '00000000-0000-0000-0000-000000000011',
+    'fixture-code-1',
+    'password-reset',
+    'roundtrip@example.com',
+    '2025-02-08T15:13:00Z',
+    '2099-01-01T00:00:00Z'
+  ),
+  (
+    '00000000-0000-0000-0000-000000000012',
+    'fixture-code-2',
+    'password-reset',
+    'roundtrip@example.com',
+    '2025-02-08T15:14:00Z',
+    '2099-01-01T00:00:00Z'
+  ),
+  (
+    '00000000-0000-0000-0000-000000000013',
+    'fixture-code-3',
+    'password-reset',
+    'roundtrip@example.com',
+    '2025-02-08T15:15:00Z',
+    '2099-01-01T00:00:00Z'
+  );

--- a/internal/models/migrations/testdata/schema/20250126124400_credentials_table.txt
+++ b/internal/models/migrations/testdata/schema/20250126124400_credentials_table.txt
@@ -1,0 +1,18 @@
+column	credentials.created_at	timestamp(0) with time zone NOT NULL
+column	credentials.email	text NOT NULL
+column	credentials.id	uuid NOT NULL
+column	credentials.password	text
+column	credentials.updated_at	timestamp(0) with time zone NOT NULL
+comment	schema public	standard public schema
+constraint	credentials.credentials_created_at_not_null	NOT NULL created_at
+constraint	credentials.credentials_email_check	CHECK ((email <> ''::text))
+constraint	credentials.credentials_email_key	UNIQUE (email)
+constraint	credentials.credentials_email_not_null	NOT NULL email
+constraint	credentials.credentials_id_not_null	NOT NULL id
+constraint	credentials.credentials_pkey	PRIMARY KEY (id)
+constraint	credentials.credentials_updated_at_not_null	NOT NULL updated_at
+extension	plpgsql	1.0
+index	credentials_email_key	CREATE UNIQUE INDEX credentials_email_key ON public.credentials USING btree (email)
+index	credentials_pkey	CREATE UNIQUE INDEX credentials_pkey ON public.credentials USING btree (id)
+relation	credentials	r
+schema	public	pg_database_owner=UC/pg_database_owner,=U/pg_database_owner

--- a/internal/models/migrations/testdata/schema/20250208151300_short_codes_table.txt
+++ b/internal/models/migrations/testdata/schema/20250208151300_short_codes_table.txt
@@ -1,0 +1,39 @@
+column	credentials.created_at	timestamp(0) with time zone NOT NULL
+column	credentials.email	text NOT NULL
+column	credentials.id	uuid NOT NULL
+column	credentials.password	text
+column	credentials.updated_at	timestamp(0) with time zone NOT NULL
+column	short_codes.code	text NOT NULL
+column	short_codes.created_at	timestamp(0) with time zone NOT NULL
+column	short_codes.data	bytea
+column	short_codes.deleted_at	timestamp(0) with time zone
+column	short_codes.deleted_comment	text
+column	short_codes.expires_at	timestamp(0) with time zone NOT NULL
+column	short_codes.id	uuid NOT NULL
+column	short_codes.target	text NOT NULL
+column	short_codes.usage	text NOT NULL
+comment	schema public	standard public schema
+constraint	credentials.credentials_created_at_not_null	NOT NULL created_at
+constraint	credentials.credentials_email_check	CHECK ((email <> ''::text))
+constraint	credentials.credentials_email_key	UNIQUE (email)
+constraint	credentials.credentials_email_not_null	NOT NULL email
+constraint	credentials.credentials_id_not_null	NOT NULL id
+constraint	credentials.credentials_pkey	PRIMARY KEY (id)
+constraint	credentials.credentials_updated_at_not_null	NOT NULL updated_at
+constraint	short_codes.short_codes_code_not_null	NOT NULL code
+constraint	short_codes.short_codes_created_at_not_null	NOT NULL created_at
+constraint	short_codes.short_codes_expires_at_not_null	NOT NULL expires_at
+constraint	short_codes.short_codes_id_not_null	NOT NULL id
+constraint	short_codes.short_codes_pkey	PRIMARY KEY (id)
+constraint	short_codes.short_codes_target_not_null	NOT NULL target
+constraint	short_codes.short_codes_usage_not_null	NOT NULL usage
+extension	plpgsql	1.0
+index	credentials_email_key	CREATE UNIQUE INDEX credentials_email_key ON public.credentials USING btree (email)
+index	credentials_pkey	CREATE UNIQUE INDEX credentials_pkey ON public.credentials USING btree (id)
+index	short_codes_created_at_idx	CREATE INDEX short_codes_created_at_idx ON public.short_codes USING btree (created_at)
+index	short_codes_deleted_idx	CREATE INDEX short_codes_deleted_idx ON public.short_codes USING btree (deleted_at, expires_at)
+index	short_codes_pkey	CREATE UNIQUE INDEX short_codes_pkey ON public.short_codes USING btree (id)
+index	short_codes_target_usage_idx	CREATE INDEX short_codes_target_usage_idx ON public.short_codes USING btree (target, usage)
+relation	credentials	r
+relation	short_codes	r
+schema	public	pg_database_owner=UC/pg_database_owner,=U/pg_database_owner

--- a/internal/models/migrations/testdata/schema/20250319184100_add_credentials_roles.txt
+++ b/internal/models/migrations/testdata/schema/20250319184100_add_credentials_roles.txt
@@ -1,0 +1,42 @@
+column	credentials.created_at	timestamp(0) with time zone NOT NULL
+column	credentials.email	text NOT NULL
+column	credentials.id	uuid NOT NULL
+column	credentials.password	text
+column	credentials.role	text NOT NULL DEFAULT 'user'::text
+column	credentials.updated_at	timestamp(0) with time zone NOT NULL
+column	short_codes.code	text NOT NULL
+column	short_codes.created_at	timestamp(0) with time zone NOT NULL
+column	short_codes.data	bytea
+column	short_codes.deleted_at	timestamp(0) with time zone
+column	short_codes.deleted_comment	text
+column	short_codes.expires_at	timestamp(0) with time zone NOT NULL
+column	short_codes.id	uuid NOT NULL
+column	short_codes.target	text NOT NULL
+column	short_codes.usage	text NOT NULL
+comment	schema public	standard public schema
+constraint	credentials.credentials_created_at_not_null	NOT NULL created_at
+constraint	credentials.credentials_email_check	CHECK ((email <> ''::text))
+constraint	credentials.credentials_email_key	UNIQUE (email)
+constraint	credentials.credentials_email_not_null	NOT NULL email
+constraint	credentials.credentials_id_not_null	NOT NULL id
+constraint	credentials.credentials_pkey	PRIMARY KEY (id)
+constraint	credentials.credentials_role_not_null	NOT NULL role
+constraint	credentials.credentials_updated_at_not_null	NOT NULL updated_at
+constraint	short_codes.short_codes_code_not_null	NOT NULL code
+constraint	short_codes.short_codes_created_at_not_null	NOT NULL created_at
+constraint	short_codes.short_codes_expires_at_not_null	NOT NULL expires_at
+constraint	short_codes.short_codes_id_not_null	NOT NULL id
+constraint	short_codes.short_codes_pkey	PRIMARY KEY (id)
+constraint	short_codes.short_codes_target_not_null	NOT NULL target
+constraint	short_codes.short_codes_usage_not_null	NOT NULL usage
+extension	plpgsql	1.0
+index	credentials_email_key	CREATE UNIQUE INDEX credentials_email_key ON public.credentials USING btree (email)
+index	credentials_pkey	CREATE UNIQUE INDEX credentials_pkey ON public.credentials USING btree (id)
+index	credentials_role_idx	CREATE INDEX credentials_role_idx ON public.credentials USING btree (role)
+index	short_codes_created_at_idx	CREATE INDEX short_codes_created_at_idx ON public.short_codes USING btree (created_at)
+index	short_codes_deleted_idx	CREATE INDEX short_codes_deleted_idx ON public.short_codes USING btree (deleted_at, expires_at)
+index	short_codes_pkey	CREATE UNIQUE INDEX short_codes_pkey ON public.short_codes USING btree (id)
+index	short_codes_target_usage_idx	CREATE INDEX short_codes_target_usage_idx ON public.short_codes USING btree (target, usage)
+relation	credentials	r
+relation	short_codes	r
+schema	public	pg_database_owner=UC/pg_database_owner,=U/pg_database_owner

--- a/internal/models/migrations/testdata/schema/20260510140000_short_codes_active_unique.txt
+++ b/internal/models/migrations/testdata/schema/20260510140000_short_codes_active_unique.txt
@@ -1,0 +1,43 @@
+column	credentials.created_at	timestamp(0) with time zone NOT NULL
+column	credentials.email	text NOT NULL
+column	credentials.id	uuid NOT NULL
+column	credentials.password	text
+column	credentials.role	text NOT NULL DEFAULT 'user'::text
+column	credentials.updated_at	timestamp(0) with time zone NOT NULL
+column	short_codes.code	text NOT NULL
+column	short_codes.created_at	timestamp(0) with time zone NOT NULL
+column	short_codes.data	bytea
+column	short_codes.deleted_at	timestamp(0) with time zone
+column	short_codes.deleted_comment	text
+column	short_codes.expires_at	timestamp(0) with time zone NOT NULL
+column	short_codes.id	uuid NOT NULL
+column	short_codes.target	text NOT NULL
+column	short_codes.usage	text NOT NULL
+comment	schema public	standard public schema
+constraint	credentials.credentials_created_at_not_null	NOT NULL created_at
+constraint	credentials.credentials_email_check	CHECK ((email <> ''::text))
+constraint	credentials.credentials_email_key	UNIQUE (email)
+constraint	credentials.credentials_email_not_null	NOT NULL email
+constraint	credentials.credentials_id_not_null	NOT NULL id
+constraint	credentials.credentials_pkey	PRIMARY KEY (id)
+constraint	credentials.credentials_role_not_null	NOT NULL role
+constraint	credentials.credentials_updated_at_not_null	NOT NULL updated_at
+constraint	short_codes.short_codes_code_not_null	NOT NULL code
+constraint	short_codes.short_codes_created_at_not_null	NOT NULL created_at
+constraint	short_codes.short_codes_expires_at_not_null	NOT NULL expires_at
+constraint	short_codes.short_codes_id_not_null	NOT NULL id
+constraint	short_codes.short_codes_pkey	PRIMARY KEY (id)
+constraint	short_codes.short_codes_target_not_null	NOT NULL target
+constraint	short_codes.short_codes_usage_not_null	NOT NULL usage
+extension	plpgsql	1.0
+index	credentials_email_key	CREATE UNIQUE INDEX credentials_email_key ON public.credentials USING btree (email)
+index	credentials_pkey	CREATE UNIQUE INDEX credentials_pkey ON public.credentials USING btree (id)
+index	credentials_role_idx	CREATE INDEX credentials_role_idx ON public.credentials USING btree (role)
+index	short_codes_active_target_usage_uniq	CREATE UNIQUE INDEX short_codes_active_target_usage_uniq ON public.short_codes USING btree (target, usage) WHERE (deleted_at IS NULL)
+index	short_codes_created_at_idx	CREATE INDEX short_codes_created_at_idx ON public.short_codes USING btree (created_at)
+index	short_codes_deleted_idx	CREATE INDEX short_codes_deleted_idx ON public.short_codes USING btree (deleted_at, expires_at)
+index	short_codes_pkey	CREATE UNIQUE INDEX short_codes_pkey ON public.short_codes USING btree (id)
+index	short_codes_target_usage_idx	CREATE INDEX short_codes_target_usage_idx ON public.short_codes USING btree (target, usage)
+relation	credentials	r
+relation	short_codes	r
+schema	public	pg_database_owner=UC/pg_database_owner,=U/pg_database_owner

--- a/internal/models/migrations/testdata/schema/20260723140000_fix_credentials_role_default.txt
+++ b/internal/models/migrations/testdata/schema/20260723140000_fix_credentials_role_default.txt
@@ -1,0 +1,44 @@
+column	credentials.created_at	timestamp(0) with time zone NOT NULL
+column	credentials.email	text NOT NULL
+column	credentials.id	uuid NOT NULL
+column	credentials.password	text
+column	credentials.role	text NOT NULL DEFAULT 'auth:user'::text
+column	credentials.updated_at	timestamp(0) with time zone NOT NULL
+column	short_codes.code	text NOT NULL
+column	short_codes.created_at	timestamp(0) with time zone NOT NULL
+column	short_codes.data	bytea
+column	short_codes.deleted_at	timestamp(0) with time zone
+column	short_codes.deleted_comment	text
+column	short_codes.expires_at	timestamp(0) with time zone NOT NULL
+column	short_codes.id	uuid NOT NULL
+column	short_codes.target	text NOT NULL
+column	short_codes.usage	text NOT NULL
+comment	schema public	standard public schema
+constraint	credentials.credentials_created_at_not_null	NOT NULL created_at
+constraint	credentials.credentials_email_check	CHECK ((email <> ''::text))
+constraint	credentials.credentials_email_key	UNIQUE (email)
+constraint	credentials.credentials_email_not_null	NOT NULL email
+constraint	credentials.credentials_id_not_null	NOT NULL id
+constraint	credentials.credentials_pkey	PRIMARY KEY (id)
+constraint	credentials.credentials_role_check	CHECK ((role = ANY (ARRAY['auth:anon'::text, 'auth:user'::text, 'auth:admin'::text, 'auth:superadmin'::text])))
+constraint	credentials.credentials_role_not_null	NOT NULL role
+constraint	credentials.credentials_updated_at_not_null	NOT NULL updated_at
+constraint	short_codes.short_codes_code_not_null	NOT NULL code
+constraint	short_codes.short_codes_created_at_not_null	NOT NULL created_at
+constraint	short_codes.short_codes_expires_at_not_null	NOT NULL expires_at
+constraint	short_codes.short_codes_id_not_null	NOT NULL id
+constraint	short_codes.short_codes_pkey	PRIMARY KEY (id)
+constraint	short_codes.short_codes_target_not_null	NOT NULL target
+constraint	short_codes.short_codes_usage_not_null	NOT NULL usage
+extension	plpgsql	1.0
+index	credentials_email_key	CREATE UNIQUE INDEX credentials_email_key ON public.credentials USING btree (email)
+index	credentials_pkey	CREATE UNIQUE INDEX credentials_pkey ON public.credentials USING btree (id)
+index	credentials_role_idx	CREATE INDEX credentials_role_idx ON public.credentials USING btree (role)
+index	short_codes_active_target_usage_uniq	CREATE UNIQUE INDEX short_codes_active_target_usage_uniq ON public.short_codes USING btree (target, usage) WHERE (deleted_at IS NULL)
+index	short_codes_created_at_idx	CREATE INDEX short_codes_created_at_idx ON public.short_codes USING btree (created_at)
+index	short_codes_deleted_idx	CREATE INDEX short_codes_deleted_idx ON public.short_codes USING btree (deleted_at, expires_at)
+index	short_codes_pkey	CREATE UNIQUE INDEX short_codes_pkey ON public.short_codes USING btree (id)
+index	short_codes_target_usage_idx	CREATE INDEX short_codes_target_usage_idx ON public.short_codes USING btree (target, usage)
+relation	credentials	r
+relation	short_codes	r
+schema	public	pg_database_owner=UC/pg_database_owner,=U/pg_database_owner


### PR DESCRIPTION
## Summary

- verify all five migrations through forward, fixture, rollback, and replay cycles
- exercise credential backfill and duplicate short-code cleanup against real data
- record append-only schema snapshots and run generation against the built database image

## Breaking changes

None.

## Test plan

- [x] migration roundtrip test on PostgreSQL 18
- [x] deterministic snapshot regeneration
- [x] `pnpm lint:ci` and `pnpm lint:go`
- [x] `a-novel test --type=go -y`
- [x] `a-novel build --type=go -y`

Closes #1182.
Part of a-novel/.github#237.