### PR TITLE
ci(ci): use shared Go generation action

### DIFF
--- a/.github/workflows/approve-pr.yaml
+++ b/.github/workflows/approve-pr.yaml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/approve-pr@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/approve-pr@v1.28.0
         with:
           pull_request: ${{ inputs.pull_request }}
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}

--- a/.github/workflows/auto-approve-dependabot.yaml
+++ b/.github/workflows/auto-approve-dependabot.yaml
@@ -20,7 +20,7 @@ jobs:
     # the callee mints a scoped App token and declares permissions: {}; the caller sets the ceiling, so it must not hand down
     # the repository default.
     permissions: {}
-    uses: a-novel-kit/workflows/.github/workflows/auto-approve-dependabot-run.yaml@v1.27.1
+    uses: a-novel-kit/workflows/.github/workflows/auto-approve-dependabot-run.yaml@v1.28.0
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       dependency_bot_login: ${{ vars.DEPENDENCY_BOT_LOGIN }}

--- a/.github/workflows/auto-assign-author.yaml
+++ b/.github/workflows/auto-assign-author.yaml
@@ -10,6 +10,6 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/assign-bot@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/assign-bot@v1.28.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/derive-status.yaml
+++ b/.github/workflows/derive-status.yaml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: read
       issues: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.28.0
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/epic-freeze.yaml
+++ b/.github/workflows/epic-freeze.yaml
@@ -33,7 +33,7 @@ jobs:
     # a stray forward is sweep-only, so a per-PR run can never re-enqueue.
     permissions: {}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.28.0
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/epic-rollback.yaml
+++ b/.github/workflows/epic-rollback.yaml
@@ -52,7 +52,7 @@ jobs:
     # the repository default.
     permissions:
       contents: read
-    uses: a-novel-kit/workflows/.github/workflows/epic-rollback-run.yaml@v1.27.1
+    uses: a-novel-kit/workflows/.github/workflows/epic-rollback-run.yaml@v1.28.0
     with:
       epic_number: ${{ inputs.epic_number }}
       confirm: ${{ inputs.confirm }}

--- a/.github/workflows/hotfix.yaml
+++ b/.github/workflows/hotfix.yaml
@@ -51,7 +51,7 @@ jobs:
     permissions:
       contents: write
       actions: read
-    uses: a-novel-kit/workflows/.github/workflows/hotfix-run.yaml@v1.27.1
+    uses: a-novel-kit/workflows/.github/workflows/hotfix-run.yaml@v1.28.0
     with:
       line: ${{ inputs.line }}
       fix_ref: ${{ inputs.fix_ref }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,12 +22,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check schema snapshots
-        uses: a-novel-kit/workflows/generic-actions/check-append-only@v1.27.1
+        uses: a-novel-kit/workflows/generic-actions/check-append-only@v1.28.0
         with:
           path: internal/models/migrations/testdata/schema
           base: ${{ github.event.pull_request.base.sha }}
       - name: Check migration SQL
-        uses: a-novel-kit/workflows/generic-actions/check-append-only@v1.27.1
+        uses: a-novel-kit/workflows/generic-actions/check-append-only@v1.28.0
         with:
           path: ":(glob)internal/models/migrations/*.sql"
           base: ${{ github.event.pull_request.base.sha }}
@@ -56,18 +56,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: "go.mod"
-      - name: go generate
-        shell: bash
-        run: go generate ./...
-      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.27.1
-        with:
-          fail_message: go generate definitions are not up-to-date, please run 'go generate ./...' and commit the changes
+      - uses: a-novel-kit/workflows/go-actions/generate-go@v1.28.0
 
   generated-pnpm:
     runs-on: ubuntu-latest
@@ -75,7 +64,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/setup-node@v1.27.1
+      - uses: a-novel-kit/workflows/node-actions/setup-node@v1.28.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -84,7 +73,7 @@ jobs:
       - name: pnpm generate:mjml
         shell: bash
         run: pnpm generate:mjml
-      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.28.0
         with:
           fail_message: mail templates are not up-to-date, please run 'pnpm generate' and commit the changes
 
@@ -93,7 +82,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.27.1
+      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.28.0
 
   lint-node:
     runs-on: ubuntu-latest
@@ -101,7 +90,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.27.1
+      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.28.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -116,7 +105,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/generic-actions/lint-shell@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/lint-shell@v1.28.0
         with:
           # renovate: datasource=github-releases depName=koalaman/shellcheck
           version: "0.11.0"
@@ -129,7 +118,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/generic-actions/lint-dockerfile@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/lint-dockerfile@v1.28.0
         with:
           # renovate: datasource=github-releases depName=hadolint/hadolint
           version: "2.14.0"
@@ -143,7 +132,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/security-actions/lint-semgrep@v1.27.1
+      - uses: a-novel-kit/workflows/security-actions/lint-semgrep@v1.28.0
         with:
           ruleset: service
           # renovate: datasource=docker depName=semgrep/semgrep
@@ -159,7 +148,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/security-actions/scan-secrets@v1.27.1
+      - uses: a-novel-kit/workflows/security-actions/scan-secrets@v1.28.0
         with:
           config: .gitleaks.toml
           # renovate: datasource=github-releases depName=gitleaks/gitleaks
@@ -175,7 +164,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/security-actions/lint-workflows@v1.27.1
+      - uses: a-novel-kit/workflows/security-actions/lint-workflows@v1.28.0
         with:
           # renovate: datasource=docker depName=ghcr.io/zizmorcore/zizmor
           version: "1.28.0"
@@ -225,7 +214,7 @@ jobs:
         run: |
           go run ./cmd/init
           go run ./cmd/init
-      - uses: a-novel-kit/workflows/go-actions/test-go@v1.27.1
+      - uses: a-novel-kit/workflows/go-actions/test-go@v1.28.0
         id: test
         with:
           filter_extra_patterns: "| grep /internal"
@@ -247,7 +236,7 @@ jobs:
     outputs:
       artifact-id: ${{ steps.test.outputs.artifact-id }}
     steps:
-      - uses: a-novel-kit/workflows/go-actions/test-go@v1.27.1
+      - uses: a-novel-kit/workflows/go-actions/test-go@v1.28.0
         id: test
         with:
           filter_extra_patterns: "| grep /pkg"
@@ -342,7 +331,7 @@ jobs:
       SUPER_ADMIN_PASSWORD: admin
       MAIL_HOST: http://0.0.0.0:8025
     steps:
-      - uses: a-novel-kit/workflows/node-actions/test-node@v1.27.1
+      - uses: a-novel-kit/workflows/node-actions/test-node@v1.28.0
         id: test
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -367,7 +356,7 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         id: build
         with:
           file: builds/database.Dockerfile
@@ -408,7 +397,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.28.0
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -448,7 +437,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.28.0
         with:
           file: builds/init.Dockerfile
           image_name: ${{ github.repository }}/jobs/init
@@ -517,7 +506,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -541,7 +530,7 @@ jobs:
     # integration run), so this job only builds + pushes it. skip_healthcheck
     # drops the redundant smoke run and the container constellation it needed.
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         id: build
         with:
           file: builds/standalone.rest.Dockerfile
@@ -555,7 +544,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/build-node@v1.27.1
+      - uses: a-novel-kit/workflows/node-actions/build-node@v1.28.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -568,7 +557,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.28.0
         with:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
           coverage_files: coverage.txt,coverage_pkg.txt,coverage/*

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -34,7 +34,7 @@ jobs:
     # the callee mints its own App token and declares permissions: {}; the caller sets the ceiling, so it must not hand down
     # the repository default.
     permissions: {}
-    uses: a-novel-kit/workflows/.github/workflows/merge-gate-run.yaml@v1.27.1
+    uses: a-novel-kit/workflows/.github/workflows/merge-gate-run.yaml@v1.28.0
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       kill_switch: ${{ vars.AGENT_KILL_SWITCH }}

--- a/.github/workflows/node-audit.yaml
+++ b/.github/workflows/node-audit.yaml
@@ -11,7 +11,7 @@ jobs:
       contents: write
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/audit@v1.27.1
+      - uses: a-novel-kit/workflows/node-actions/audit@v1.28.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release-train.yaml
+++ b/.github/workflows/release-train.yaml
@@ -39,7 +39,7 @@ jobs:
     # the repository default.
     permissions:
       contents: read
-    uses: a-novel-kit/workflows/.github/workflows/release-train-run.yaml@v1.27.1
+    uses: a-novel-kit/workflows/.github/workflows/release-train-run.yaml@v1.28.0
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       epic_number: ${{ inputs.epic_number }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
       tag: ${{ steps.core.outputs.tag }}
     steps:
       - id: core
-        uses: a-novel-kit/workflows/publish-actions/release-core@v1.27.1
+        uses: a-novel-kit/workflows/publish-actions/release-core@v1.28.0
         with:
           # renovate: datasource=go depName=github.com/a-novel-kit/stack/cli
           cli_version: "1.7.5"
@@ -73,7 +73,7 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:
           file: builds/database.Dockerfile
           image_name: ${{ github.repository }}/database
@@ -115,7 +115,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.28.0
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -157,7 +157,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.28.0
         with:
           file: builds/init.Dockerfile
           image_name: ${{ github.repository }}/jobs/init
@@ -223,7 +223,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -290,7 +290,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:
           file: builds/standalone.rest.Dockerfile
           image_name: ${{ github.repository }}/standalone-rest
@@ -312,7 +312,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: a-novel-kit/workflows/publish-actions/npm@v1.27.1
+      - uses: a-novel-kit/workflows/publish-actions/npm@v1.28.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}
@@ -334,7 +334,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.28.0
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
       security-events: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/renovate@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/renovate@v1.28.0
         with:
           allowed_commands: |
             [


### PR DESCRIPTION
## Summary

- Replaces the repository-local generated-Go CI sequence with `generate-go@v1.28.0`.
- Preserves caller-owned job services and dependencies.
- Aligns all shared workflow-action references on the released `v1.28.0` tag.

## Layers changed

- **CI**: generated-code verification and shared-action pins.

## Breaking changes

None.

## Test plan

- [x] Repository Prettier check passes.
- [x] Focused workflow diff review and stale-pin guard pass.
- [ ] CI green

Closes #1187

Part of a-novel/.github#239.