### PR TITLE
feat(rest)!: namespace Authentication API at v2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,10 +14,10 @@ Once the service is up (`a-novel run start service-authentication/rest`), the RE
 
 ```bash
 # Liveness
-curl http://localhost:${SERVICE_AUTHENTICATION_REST_PORT}/ping
+curl http://localhost:${SERVICE_AUTHENTICATION_REST_PORT}/v2/ping
 
 # Dependency check (Postgres, JSON Keys, SMTP)
-curl http://localhost:${SERVICE_AUTHENTICATION_REST_PORT}/healthcheck
+curl http://localhost:${SERVICE_AUTHENTICATION_REST_PORT}/v2/healthcheck
 ```
 
 ### Authentication flows
@@ -32,10 +32,10 @@ PASSWORD=<PASSWORD>
 
 ```bash
 # Anonymous session — the entry point for register / login.
-ACCESS_TOKEN=$(curl -X PUT http://localhost:${SERVICE_AUTHENTICATION_REST_PORT}/session/anon | jq -r '.accessToken')
+ACCESS_TOKEN=$(curl -X PUT http://localhost:${SERVICE_AUTHENTICATION_REST_PORT}/v2/session/anon | jq -r '.accessToken')
 
 # Inspect the current session.
-curl -X GET http://localhost:${SERVICE_AUTHENTICATION_REST_PORT}/session \
+curl -X GET http://localhost:${SERVICE_AUTHENTICATION_REST_PORT}/v2/session \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 
@@ -45,7 +45,7 @@ Registration is a two-step, email-verified flow: request a short code, read it f
 
 ```bash
 # Request a short code (emailed to the user).
-curl -X PUT http://localhost:${SERVICE_AUTHENTICATION_REST_PORT}/short-code/register \
+curl -X PUT http://localhost:${SERVICE_AUTHENTICATION_REST_PORT}/v2/short-code/register \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -H "Content-Type: application/json" \
   -d "{\"email\": \"$USER\", \"lang\": \"en\"}"
@@ -59,7 +59,7 @@ SHORT_CODE=$(
 
 # Complete registration with the code. Returns both tokens.
 TOKEN=$(
-  curl -X PUT http://localhost:${SERVICE_AUTHENTICATION_REST_PORT}/credentials \
+  curl -X PUT http://localhost:${SERVICE_AUTHENTICATION_REST_PORT}/v2/credentials \
     -H "Authorization: Bearer $ACCESS_TOKEN" \
     -H "Content-Type: application/json" \
     -d "{\"email\": \"$USER\", \"password\": \"$PASSWORD\", \"shortCode\": \"$SHORT_CODE\"}"
@@ -72,7 +72,7 @@ REFRESH_TOKEN=$(echo $TOKEN | jq -r '.refreshToken')
 
 ```bash
 TOKEN=$(
-  curl -X PUT http://localhost:${SERVICE_AUTHENTICATION_REST_PORT}/session \
+  curl -X PUT http://localhost:${SERVICE_AUTHENTICATION_REST_PORT}/v2/session \
     -H "Authorization: Bearer $ACCESS_TOKEN" \
     -H "Content-Type: application/json" \
     -d "{\"email\": \"$USER\", \"password\": \"$PASSWORD\"}"
@@ -85,7 +85,7 @@ REFRESH_TOKEN=$(echo $TOKEN | jq -r '.refreshToken')
 
 ```bash
 TOKEN=$(
-  curl -X PATCH http://localhost:${SERVICE_AUTHENTICATION_REST_PORT}/session \
+  curl -X PATCH http://localhost:${SERVICE_AUTHENTICATION_REST_PORT}/v2/session \
     -H "Content-Type: application/json" \
     -d "{\"accessToken\": \"$ACCESS_TOKEN\", \"refreshToken\": \"$REFRESH_TOKEN\"}"
 )
@@ -123,7 +123,7 @@ Sessions are a pair of JWTs, both signed and verified through the [JSON Keys ser
 | Access token  | Authorizes API calls.           | Short (minutes) |
 | Refresh token | Mints a new pair without login. | Long (days)     |
 
-A client authenticates once, then uses the access token until it expires and the refresh token to roll a fresh pair (`PATCH /session`) without re-sending credentials.
+A client authenticates once, then uses the access token until it expires and the refresh token to roll a fresh pair (`PATCH /v2/session`) without re-sending credentials.
 
 ### Short codes
 

--- a/builds/podman-compose.yaml
+++ b/builds/podman-compose.yaml
@@ -8,7 +8,7 @@ services:
     ports:
       # SMTP listener for the rest target, UI for the operator's browser. A rest
       # process on the host needs the SMTP publish to reach mailpit, or
-      # /healthcheck reports "client:smtp down".
+      # /v2/healthcheck reports "client:smtp down".
       - "${SMTP_PORT}:1025"
       - "${MAIL_UI_PORT}:8025"
     networks:

--- a/builds/rest.Dockerfile
+++ b/builds/rest.Dockerfile
@@ -42,7 +42,7 @@ COPY --from=builder /rest /rest
 
 # Alpine ships BusyBox wget — no extra package needed for the healthcheck.
 HEALTHCHECK --interval=1s --timeout=5s --retries=10 --start-period=1s \
-  CMD wget -qO /dev/null http://localhost:8080/ping || exit 1
+  CMD wget -qO /dev/null http://localhost:8080/v2/ping || exit 1
 
 # Make sure the executable uses the default port.
 ENV REST_PORT=8080

--- a/builds/standalone.rest.Dockerfile
+++ b/builds/standalone.rest.Dockerfile
@@ -42,7 +42,7 @@ COPY --from=builder /init /init
 
 # Alpine ships BusyBox wget — no extra package needed for the healthcheck.
 HEALTHCHECK --interval=1s --timeout=5s --retries=10 --start-period=1s \
-  CMD wget -qO /dev/null http://localhost:8080/ping || exit 1
+  CMD wget -qO /dev/null http://localhost:8080/v2/ping || exit 1
 
 # Make sure the executable uses the default port.
 ENV REST_PORT=8080

--- a/cmd/rest/main.go
+++ b/cmd/rest/main.go
@@ -225,37 +225,39 @@ func main() {
 	}))
 	router.Use(cfg.HttpLogger.Logger())
 
-	router.Get("/ping", handlerPing.ServeHTTP)
-	router.Get("/healthcheck", handlerHealth.ServeHTTP)
+	router.Route("/v2", func(api chi.Router) {
+		api.Get("/ping", handlerPing.ServeHTTP)
+		api.Get("/healthcheck", handlerHealth.ServeHTTP)
 
-	router.Route("/session", func(r chi.Router) {
-		r.Put("/", handlerTokenCreate.ServeHTTP)
-		r.Put("/anon", handlerTokenCreateAnon.ServeHTTP)
+		api.Route("/session", func(r chi.Router) {
+			r.Put("/", handlerTokenCreate.ServeHTTP)
+			r.Put("/anon", handlerTokenCreateAnon.ServeHTTP)
 
-		withAuth(r).Get("/", handlerClaimsGet.ServeHTTP)
-		r.Patch("/", handlerTokenRefresh.ServeHTTP)
-	})
+			withAuth(r).Get("/", handlerClaimsGet.ServeHTTP)
+			r.Patch("/", handlerTokenRefresh.ServeHTTP)
+		})
 
-	router.Route("/credentials", func(r chi.Router) {
-		withAuth(r, "credentials:get").Get("/", handlerCredentialsGet.ServeHTTP)
-		withAuth(r, "credentials:exist").Head("/", handlerCredentialsExist.ServeHTTP)
-		withAuth(r, "credentials:list").Get("/all", handlerCredentialsList.ServeHTTP)
+		api.Route("/credentials", func(r chi.Router) {
+			withAuth(r, "credentials:get").Get("/", handlerCredentialsGet.ServeHTTP)
+			withAuth(r, "credentials:exist").Head("/", handlerCredentialsExist.ServeHTTP)
+			withAuth(r, "credentials:list").Get("/all", handlerCredentialsList.ServeHTTP)
 
-		withAuth(r, "credentials:create").Put("/", handlerCredentialsCreate.ServeHTTP)
-		withAuth(r, "credentials:email:patch").
-			Patch("/email", handlerCredentialsUpdateEmail.ServeHTTP)
-		withAuth(r, "credentials:password:patch").
-			Patch("/password", handlerCredentialsUpdatePassword.ServeHTTP)
-		withAuth(r, "credentials:password:reset").
-			Put("/password", handlerCredentialsResetPassword.ServeHTTP)
-		withAuth(r, "credentials:role:patch").
-			Patch("/role", handlerCredentialsUpdateRole.ServeHTTP)
-	})
+			withAuth(r, "credentials:create").Put("/", handlerCredentialsCreate.ServeHTTP)
+			withAuth(r, "credentials:email:patch").
+				Patch("/email", handlerCredentialsUpdateEmail.ServeHTTP)
+			withAuth(r, "credentials:password:patch").
+				Patch("/password", handlerCredentialsUpdatePassword.ServeHTTP)
+			withAuth(r, "credentials:password:reset").
+				Put("/password", handlerCredentialsResetPassword.ServeHTTP)
+			withAuth(r, "credentials:role:patch").
+				Patch("/role", handlerCredentialsUpdateRole.ServeHTTP)
+		})
 
-	router.Route("/short-code", func(r chi.Router) {
-		withAuth(r, "shortCode:register").Put("/register", handlerShortCodeCreateRegister.ServeHTTP)
-		withAuth(r, "shortCode:email:update").Put("/update-email", handlerShortCodeCreateEmailUpdate.ServeHTTP)
-		withAuth(r, "shortCode:password:reset").Put("/update-password", handlerShortCodeCreatePasswordReset.ServeHTTP)
+		api.Route("/short-code", func(r chi.Router) {
+			withAuth(r, "shortCode:register").Put("/register", handlerShortCodeCreateRegister.ServeHTTP)
+			withAuth(r, "shortCode:email:update").Put("/update-email", handlerShortCodeCreateEmailUpdate.ServeHTTP)
+			withAuth(r, "shortCode:password:reset").Put("/update-password", handlerShortCodeCreatePasswordReset.ServeHTTP)
+		})
 	})
 
 	// =================================================================================================================

--- a/internal/handlers/rest.health.go
+++ b/internal/handlers/rest.health.go
@@ -22,7 +22,7 @@ const (
 )
 
 // RestHealthStatus is the JSON representation of a single dependency's health.
-// /healthcheck is unauthenticated and public, so the response carries no error
+// /v2/healthcheck is unauthenticated and public, so the response carries no error
 // message: raw errors routinely include internal hostnames, ports, or schema names.
 // Operators read the underlying error off the trace span.
 type RestHealthStatus struct {
@@ -52,7 +52,7 @@ type RestHealthApiJsonKeys interface {
 	) (*servicejsonkeys.StatusResponse, error)
 }
 
-// RestHealth is the handler backing /healthcheck. It probes each downstream
+// RestHealth is the handler backing /v2/healthcheck. It probes each downstream
 // dependency and reports their combined status; see RestHealthStatus for why the
 // response withholds error detail.
 type RestHealth struct {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -33,7 +33,7 @@ info:
     url: "https://raw.githubusercontent.com/a-novel/service-authentication/refs/heads/master/LICENSE"
 
 paths:
-  /ping:
+  /v2/ping:
     get:
       operationId: ping
       summary: Ping the server.
@@ -41,7 +41,7 @@ paths:
         A simple endpoint to check if the server is up and running. It always returns the same response.
 
         This does not report on the server's dependencies. To assess the server's actual health, use the
-        `/healthcheck` endpoint.
+        `/v2/healthcheck` endpoint.
       tags: [health]
       security: []
       responses:
@@ -52,7 +52,7 @@ paths:
         default:
           $ref: "#/components/responses/internalError"
 
-  /healthcheck:
+  /v2/healthcheck:
     get:
       operationId: healthcheck
       summary: Health diagnosis of the server.
@@ -68,7 +68,7 @@ paths:
         default:
           $ref: "#/components/responses/internalError"
 
-  /session:
+  /v2/session:
     get:
       operationId: claimsGet
       summary: Returns the claims of an authenticated user.
@@ -129,7 +129,7 @@ paths:
         default:
           $ref: "#/components/responses/internalError"
 
-  /session/anon:
+  /v2/session/anon:
     put:
       operationId: tokenCreateAnon
       summary: Create a new anonymous access token.
@@ -146,7 +146,7 @@ paths:
         default:
           $ref: "#/components/responses/internalError"
 
-  /credentials:
+  /v2/credentials:
     head:
       operationId: credentialsExists
       summary: Check if a given email is registered in the database.
@@ -201,7 +201,7 @@ paths:
       summary: Register a new user.
       description: |
         Create a new user account. The user must have a short-code available, generated during pre-registration. If not, 
-        use `[PUT] /short-code/register` first.
+        use `[PUT] /v2/short-code/register` first.
       tags: [credentials]
       security:
         - BearerAuth: ["credentials:create"]
@@ -221,7 +221,7 @@ paths:
         default:
           $ref: "#/components/responses/internalError"
 
-  /credentials/all:
+  /v2/credentials/all:
     get:
       operationId: credentialsList
       summary: Browse public credentials.
@@ -246,13 +246,13 @@ paths:
         default:
           $ref: "#/components/responses/internalError"
 
-  /credentials/email:
+  /v2/credentials/email:
     patch:
       operationId: emailUpdate
       summary: Update the user email.
       description: |
         Completes the email update process. The user must have a short-code available, generated during the initial 
-        phase. If not, use `[PUT] /short-code/update-email` first.
+        phase. If not, use `[PUT] /v2/short-code/update-email` first.
       tags: [credentials]
       security:
         - BearerAuth: ["credentials:email:patch"]
@@ -274,7 +274,7 @@ paths:
         default:
           $ref: "#/components/responses/internalError"
 
-  /credentials/password:
+  /v2/credentials/password:
     patch:
       operationId: passwordUpdate
       summary: Update the user password.
@@ -303,7 +303,7 @@ paths:
       summary: Reset the user password.
       description: |
         Completes the password reset process. The user must have a short-code available, generated during the initial 
-        phase. If not, use `[PUT] /short-code/update-password` first.
+        phase. If not, use `[PUT] /v2/short-code/update-password` first.
       tags: [credentials]
       security:
         - BearerAuth: ["credentials:password:reset"]
@@ -321,7 +321,7 @@ paths:
         default:
           $ref: "#/components/responses/internalError"
 
-  /credentials/role:
+  /v2/credentials/role:
     patch:
       operationId: roleUpdate
       summary: Update the user role.
@@ -347,7 +347,7 @@ paths:
         default:
           $ref: "#/components/responses/internalError"
 
-  /short-code/register:
+  /v2/short-code/register:
     put:
       operationId: registerInit
       summary: Start the registration process.
@@ -376,7 +376,7 @@ paths:
         default:
           $ref: "#/components/responses/internalError"
 
-  /short-code/update-email:
+  /v2/short-code/update-email:
     put:
       operationId: emailUpdateInit
       summary: Start the email update process.
@@ -405,7 +405,7 @@ paths:
         default:
           $ref: "#/components/responses/internalError"
 
-  /short-code/update-password:
+  /v2/short-code/update-password:
     put:
       operationId: passwordResetInit
       summary: Start the password reset process.

--- a/pkg/js/rest/src/api.ts
+++ b/pkg/js/rest/src/api.ts
@@ -7,7 +7,7 @@ async function decodeRawHttpResponse<T>(response: Response): Promise<T> {
 }
 
 /**
- * Status of a single health-check dependency reported by the `/healthcheck` endpoint. The
+ * Status of a single health-check dependency reported by the `/v2/healthcheck` endpoint. The
  * endpoint is unauthenticated, so it carries the dependency's state alone; the failure
  * itself is recorded on the server's traces.
  */
@@ -54,7 +54,7 @@ export class AuthenticationApi {
 
   /** Checks that the server is reachable. Throws on any non-2xx response. */
   async ping(): Promise<void> {
-    await this.fetchVoid("/ping", { method: "GET" });
+    await this.fetchVoid("/v2/ping", { method: "GET" });
   }
 
   /**
@@ -63,6 +63,6 @@ export class AuthenticationApi {
    * so inspect each entry's `status` field to detect one.
    */
   async health(): Promise<Record<string, HealthDependency>> {
-    return await this.fetch("/healthcheck", undefined, { method: "GET" });
+    return await this.fetch("/v2/healthcheck", undefined, { method: "GET" });
   }
 }

--- a/pkg/js/rest/src/claims.ts
+++ b/pkg/js/rest/src/claims.ts
@@ -20,7 +20,7 @@ export type Claims = z.infer<typeof ClaimsSchema>;
 
 /** Returns the claims carried by the given access token, as resolved by the service. */
 export async function claimsGet(api: AuthenticationApi, accessToken: string): Promise<Claims> {
-  return await api.fetch("/session", ClaimsSchema, {
+  return await api.fetch("/v2/session", ClaimsSchema, {
     headers: { ...HTTP_HEADERS.JSON, Authorization: `Bearer ${accessToken}` },
     method: "GET",
   });

--- a/pkg/js/rest/src/credentials.ts
+++ b/pkg/js/rest/src/credentials.ts
@@ -94,7 +94,7 @@ export async function credentialsGet(
   const params = new URLSearchParams();
   params.set("id", form.id);
 
-  return await api.fetch(`/credentials?${params.toString()}`, CredentialsSchema, {
+  return await api.fetch(`/v2/credentials?${params.toString()}`, CredentialsSchema, {
     headers: { ...HTTP_HEADERS.JSON, Authorization: `Bearer ${accessToken}` },
     method: "GET",
   });
@@ -110,7 +110,7 @@ export async function credentialsExists(
   params.set("email", form.email);
 
   return await api
-    .fetchVoid(`/credentials?${params.toString()}`, {
+    .fetchVoid(`/v2/credentials?${params.toString()}`, {
       headers: { ...HTTP_HEADERS.JSON, Authorization: `Bearer ${accessToken}` },
       method: "HEAD",
     })
@@ -132,7 +132,7 @@ export async function credentialsList(
   params.set("offset", `${form.offset || 0}`);
   form.roles?.forEach((role) => params.append("roles", role));
 
-  return await api.fetch(`/credentials/all?${params.toString()}`, z.array(CredentialsSchema), {
+  return await api.fetch(`/v2/credentials/all?${params.toString()}`, z.array(CredentialsSchema), {
     headers: { ...HTTP_HEADERS.JSON, Authorization: `Bearer ${accessToken}` },
     method: "GET",
   });
@@ -144,7 +144,7 @@ export async function credentialsCreate(
   accessToken: string,
   form: CredentialsCreateRequest
 ): Promise<Token> {
-  return await api.fetch("/credentials", TokenSchema, {
+  return await api.fetch("/v2/credentials", TokenSchema, {
     headers: { ...HTTP_HEADERS.JSON, Authorization: `Bearer ${accessToken}` },
     method: "PUT",
     body: JSON.stringify(form),
@@ -157,7 +157,7 @@ export async function credentialsUpdateEmail(
   accessToken: string,
   form: CredentialsUpdateEmailRequest
 ): Promise<Credentials> {
-  return await api.fetch("/credentials/email", CredentialsSchema, {
+  return await api.fetch("/v2/credentials/email", CredentialsSchema, {
     headers: { ...HTTP_HEADERS.JSON, Authorization: `Bearer ${accessToken}` },
     method: "PATCH",
     body: JSON.stringify(form),
@@ -170,7 +170,7 @@ export async function credentialsUpdatePassword(
   accessToken: string,
   form: CredentialsUpdatePasswordRequest
 ): Promise<Credentials> {
-  return await api.fetch("/credentials/password", CredentialsSchema, {
+  return await api.fetch("/v2/credentials/password", CredentialsSchema, {
     headers: { ...HTTP_HEADERS.JSON, Authorization: `Bearer ${accessToken}` },
     method: "PATCH",
     body: JSON.stringify(form),
@@ -183,7 +183,7 @@ export async function credentialsResetPassword(
   accessToken: string,
   form: CredentialsResetPasswordRequest
 ): Promise<Credentials> {
-  return await api.fetch("/credentials/password", CredentialsSchema, {
+  return await api.fetch("/v2/credentials/password", CredentialsSchema, {
     headers: { ...HTTP_HEADERS.JSON, Authorization: `Bearer ${accessToken}` },
     method: "PUT",
     body: JSON.stringify(form),
@@ -196,7 +196,7 @@ export async function credentialsUpdateRole(
   accessToken: string,
   form: CredentialsUpdateRoleRequest
 ): Promise<Credentials> {
-  return await api.fetch("/credentials/role", CredentialsSchema, {
+  return await api.fetch("/v2/credentials/role", CredentialsSchema, {
     headers: { ...HTTP_HEADERS.JSON, Authorization: `Bearer ${accessToken}` },
     method: "PATCH",
     body: JSON.stringify(form),

--- a/pkg/js/rest/src/shortCode.ts
+++ b/pkg/js/rest/src/shortCode.ts
@@ -37,7 +37,7 @@ export async function shortCodeCreateEmailUpdate(
   accessToken: string,
   form: ShortCodeCreateEmailUpdateRequest
 ): Promise<void> {
-  return await api.fetchVoid("/short-code/update-email", {
+  return await api.fetchVoid("/v2/short-code/update-email", {
     headers: { ...HTTP_HEADERS.JSON, Authorization: `Bearer ${accessToken}` },
     method: "PUT",
     body: JSON.stringify(form),
@@ -50,7 +50,7 @@ export async function shortCodeCreatePasswordReset(
   accessToken: string,
   form: ShortCodeCreatePasswordResetRequest
 ): Promise<void> {
-  return await api.fetchVoid("/short-code/update-password", {
+  return await api.fetchVoid("/v2/short-code/update-password", {
     headers: { ...HTTP_HEADERS.JSON, Authorization: `Bearer ${accessToken}` },
     method: "PUT",
     body: JSON.stringify(form),
@@ -63,7 +63,7 @@ export async function shortCodeCreateRegister(
   accessToken: string,
   form: ShortCodeCreateRegisterRequest
 ): Promise<void> {
-  return await api.fetchVoid("/short-code/register", {
+  return await api.fetchVoid("/v2/short-code/register", {
     headers: { ...HTTP_HEADERS.JSON, Authorization: `Bearer ${accessToken}` },
     method: "PUT",
     body: JSON.stringify(form),

--- a/pkg/js/rest/src/token.ts
+++ b/pkg/js/rest/src/token.ts
@@ -34,7 +34,7 @@ export type TokenRefreshRequest = z.infer<typeof TokenRefreshRequestSchema>;
 
 /** Opens an authenticated session from an email and password, returning a fresh token pair. */
 export async function tokenCreate(api: AuthenticationApi, form: TokenCreateRequest): Promise<Token> {
-  return await api.fetch("/session", TokenSchema, {
+  return await api.fetch("/v2/session", TokenSchema, {
     headers: { ...HTTP_HEADERS.JSON },
     method: "PUT",
     body: JSON.stringify(form),
@@ -43,7 +43,7 @@ export async function tokenCreate(api: AuthenticationApi, form: TokenCreateReque
 
 /** Opens an anonymous session, returning a token pair whose claims carry no user. */
 export async function tokenCreateAnon(api: AuthenticationApi): Promise<Token> {
-  return await api.fetch("/session/anon", TokenSchema, {
+  return await api.fetch("/v2/session/anon", TokenSchema, {
     headers: { ...HTTP_HEADERS.JSON },
     method: "PUT",
   });
@@ -51,7 +51,7 @@ export async function tokenCreateAnon(api: AuthenticationApi): Promise<Token> {
 
 /** Exchanges an expiring token pair for a new one, preserving the session's claims. */
 export async function tokenRefresh(api: AuthenticationApi, form: TokenRefreshRequest): Promise<Token> {
-  return await api.fetch("/session", TokenSchema, {
+  return await api.fetch("/v2/session", TokenSchema, {
     headers: { ...HTTP_HEADERS.JSON },
     method: "PATCH",
     body: JSON.stringify(form),

--- a/pkg/js/test/rest/src/credentials.test.ts
+++ b/pkg/js/test/rest/src/credentials.test.ts
@@ -28,25 +28,32 @@ import {
   registerUser,
 } from "@a-novel/service-authentication-rest-test";
 
+// The managed local test rail supplies a dynamic URL; legacy CI still exports MAIL_HOST.
+const mailUrl = (() => {
+  const value = process.env.MAIL_UI_URL ?? process.env.MAIL_HOST;
+  if (!value) throw new Error("MAIL_UI_URL or MAIL_HOST must be set");
+  return value;
+})();
+
 describe("credentialsCreate", () => {
   it("registers the user", async () => {
     const api = new AuthenticationApi(process.env.REST_URL!);
 
-    const preRegister = await preRegisterUser(api, process.env.MAIL_HOST!);
+    const preRegister = await preRegisterUser(api, mailUrl);
     await registerUser(api, preRegister);
   });
 
   it("does not register with wrong link", async () => {
     const api = new AuthenticationApi(process.env.REST_URL!);
 
-    const preRegister = await preRegisterUser(api, process.env.MAIL_HOST!);
+    const preRegister = await preRegisterUser(api, mailUrl);
     await expectStatus(registerUser(api, { ...preRegister, shortCode: "invalid" }), 403);
   });
 
   it("only registers once", async () => {
     const api = new AuthenticationApi(process.env.REST_URL!);
 
-    const preRegister = await preRegisterUser(api, process.env.MAIL_HOST!);
+    const preRegister = await preRegisterUser(api, mailUrl);
     await registerUser(api, preRegister);
     await expectStatus(registerUser(api, preRegister), 403);
   });
@@ -56,8 +63,8 @@ describe("credentialsCreate", () => {
 
     const email = generateRandomMail();
 
-    const preRegister1 = await preRegisterUser(api, process.env.MAIL_HOST!, email);
-    const preRegister2 = await preRegisterUser(api, process.env.MAIL_HOST!, email);
+    const preRegister1 = await preRegisterUser(api, mailUrl, email);
+    const preRegister2 = await preRegisterUser(api, mailUrl, email);
     await expectStatus(registerUser(api, preRegister1), 403);
     await registerUser(api, preRegister2);
   });
@@ -69,7 +76,7 @@ async function requestEmailUpdate(api: AuthenticationApi, token: Token, newEmail
     lang: Lang.En,
   });
 
-  const mailData = await checkEmail(process.env.MAIL_HOST!, `to:"${newEmail}" subject:"Email Update Request."`);
+  const mailData = await checkEmail(mailUrl, `to:"${newEmail}" subject:"Email Update Request."`);
 
   expect(mailData.html).toBeTruthy();
   const links = getHtmlMail(mailData.html as string, "a");
@@ -97,7 +104,7 @@ describe("credentialsUpdateEmail", () => {
 
     const anonToken = await tokenCreateAnon(api);
 
-    const preRegister = await preRegisterUser(api, process.env.MAIL_HOST!);
+    const preRegister = await preRegisterUser(api, mailUrl);
     const user = await registerUser(api, preRegister);
 
     const userToken = await tokenCreate(api, {
@@ -133,7 +140,7 @@ describe("credentialsUpdateEmail", () => {
 
     const anonToken = await tokenCreateAnon(api);
 
-    const preRegister = await preRegisterUser(api, process.env.MAIL_HOST!);
+    const preRegister = await preRegisterUser(api, mailUrl);
     const user = await registerUser(api, preRegister);
 
     const userToken = await tokenCreate(api, {
@@ -178,7 +185,7 @@ describe("credentialsUpdateEmail", () => {
 
     const anonToken = await tokenCreateAnon(api);
 
-    const preRegister = await preRegisterUser(api, process.env.MAIL_HOST!);
+    const preRegister = await preRegisterUser(api, mailUrl);
     const user = await registerUser(api, preRegister);
 
     const userToken = await tokenCreate(api, {
@@ -189,7 +196,7 @@ describe("credentialsUpdateEmail", () => {
     const { shortCode, target, newEmail } = await requestEmailUpdate(api, userToken);
 
     // Register a new email before updating it.
-    const preRegister2 = await preRegisterUser(api, process.env.MAIL_HOST!, newEmail);
+    const preRegister2 = await preRegisterUser(api, mailUrl, newEmail);
     await registerUser(api, preRegister2);
 
     await expectStatus(
@@ -206,7 +213,7 @@ describe("credentialsUpdatePassword", () => {
   it("changes the user password", async () => {
     const api = new AuthenticationApi(process.env.REST_URL!);
 
-    const preRegister = await preRegisterUser(api, process.env.MAIL_HOST!);
+    const preRegister = await preRegisterUser(api, mailUrl);
     const user = await registerUser(api, preRegister);
 
     const userToken = await tokenCreate(api, {
@@ -238,7 +245,7 @@ describe("credentialsUpdatePassword", () => {
   it("refuses to update if current password is incorrect", async () => {
     const api = new AuthenticationApi(process.env.REST_URL!);
 
-    const preRegister = await preRegisterUser(api, process.env.MAIL_HOST!);
+    const preRegister = await preRegisterUser(api, mailUrl);
     const user = await registerUser(api, preRegister);
 
     const userToken = await tokenCreate(api, {
@@ -277,7 +284,7 @@ async function requestPasswordReset(api: AuthenticationApi, token: Token, email:
     lang: Lang.En,
   });
 
-  const mailData = await checkEmail(process.env.MAIL_HOST!, `to:"${email}" subject:"Password Reset Request."`);
+  const mailData = await checkEmail(mailUrl, `to:"${email}" subject:"Password Reset Request."`);
 
   expect(mailData.html).toBeTruthy();
   const links = getHtmlMail(mailData.html as string, "a");
@@ -304,7 +311,7 @@ describe("credentialsResetPassword", () => {
 
     const anonToken = await tokenCreateAnon(api);
 
-    const preRegister = await preRegisterUser(api, process.env.MAIL_HOST!);
+    const preRegister = await preRegisterUser(api, mailUrl);
     const user = await registerUser(api, preRegister);
 
     const { shortCode, target } = await requestPasswordReset(api, anonToken, user.email);
@@ -336,7 +343,7 @@ describe("credentialsResetPassword", () => {
 
     const anonToken = await tokenCreateAnon(api);
 
-    const preRegister = await preRegisterUser(api, process.env.MAIL_HOST!);
+    const preRegister = await preRegisterUser(api, mailUrl);
     const user = await registerUser(api, preRegister);
 
     const requestPasswordReset1 = await requestPasswordReset(api, anonToken, user.email);
@@ -370,7 +377,7 @@ describe("credentialsUpdateRole", () => {
       password: process.env.SUPER_ADMIN_PASSWORD!,
     });
 
-    const preRegister = await preRegisterUser(api, process.env.MAIL_HOST!);
+    const preRegister = await preRegisterUser(api, mailUrl);
     const user = await registerUser(api, preRegister);
 
     expect(user.claims.roles).toStrictEqual([Role.User]);
@@ -394,7 +401,7 @@ describe("credentialsUpdateRole", () => {
   it("refuses user to change roles themselves", async () => {
     const api = new AuthenticationApi(process.env.REST_URL!);
 
-    const preRegister = await preRegisterUser(api, process.env.MAIL_HOST!);
+    const preRegister = await preRegisterUser(api, mailUrl);
     const user = await registerUser(api, preRegister);
 
     const userToken = await tokenCreate(api, {
@@ -421,7 +428,7 @@ describe("credentialsGet", () => {
       password: process.env.SUPER_ADMIN_PASSWORD!,
     });
 
-    const preRegister = await preRegisterUser(api, process.env.MAIL_HOST!);
+    const preRegister = await preRegisterUser(api, mailUrl);
     const user = await registerUser(api, preRegister);
 
     const credentials = await credentialsGet(api, superAdminToken.accessToken, {
@@ -459,7 +466,7 @@ describe("credentialsExists", () => {
       password: process.env.SUPER_ADMIN_PASSWORD!,
     });
 
-    const preRegister = await preRegisterUser(api, process.env.MAIL_HOST!);
+    const preRegister = await preRegisterUser(api, mailUrl);
     const user = await registerUser(api, preRegister);
 
     const exists = await credentialsExists(api, superAdminToken.accessToken, {
@@ -494,7 +501,7 @@ describe("credentialsList", () => {
       password: process.env.SUPER_ADMIN_PASSWORD!,
     });
 
-    const preRegister = await preRegisterUser(api, process.env.MAIL_HOST!);
+    const preRegister = await preRegisterUser(api, mailUrl);
     const user = await registerUser(api, preRegister);
 
     const credentials = await credentialsList(api, superAdminToken.accessToken, {});


### PR DESCRIPTION
## Summary

- mount the complete Authentication REST router under `/v2`, including ping and healthcheck
- update all twelve OpenAPI paths, the published JavaScript client, contributor examples, handler documentation, and both REST image probes
- keep exported client functions and all authentication/permission behavior unchanged
- let the real integration suite consume either the managed dynamic MailPit URL or the legacy CI variable

## Breaking change

There are no compatibility aliases. Every Authentication REST route now starts with `/v2`; clients and servers must upgrade together.

## Release gate — do not merge yet

The REST implementation is complete and validated, but this branch deliberately still pins the currently released JSON Keys client and images at `v2.4.1`.

After a-novel/service-json-keys#902 is force-landed and `service-json-keys@v2.5.0` is published:

- [ ] pin `github.com/a-novel/service-json-keys/v2` to exact `v2.5.0`
- [ ] pin the JSON Keys database and standalone-gRPC integration images to `v2.5.0`
- [ ] regenerate/tidy dependency metadata
- [ ] rerun Go tests, the full REST integration stack, and all builds
- [ ] mark this PR ready for review

No branch, pseudo-version, or `latest` pin will be merged.

## Verification completed against released JSON Keys v2.4.1

- [x] `pnpm format`
- [x] `pnpm lint` (Go, TypeScript, ESLint, MJML, OpenAPI)
- [x] `a-novel test --type=go -y`
- [x] `SUPER_ADMIN_EMAIL=… SUPER_ADMIN_PASSWORD=… a-novel test --type=pnpm -y` — 27 live REST integration tests, 97.1% client statement coverage
- [x] `a-novel build --type=go,pnpm -y` — four targets
- [x] `a-novel build --type=podman -y` — all five images
- [x] no unversioned owned route remains outside the child paths beneath the single `/v2` router mount

Internal tests remain mock-backed except the existing PostgreSQL DAO rail; permission configuration is not duplicated in internal tests.

Closes #1197